### PR TITLE
Add "test" to .PHONY

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -335,7 +335,7 @@ e2e:
 
 .PHONY: build.init build.check build.check.platform build.code build.code.platform build.artifacts build.artifacts.platform
 .PHONY: build.done do.build.platform.% do.build.platform do.build.artifacts.% do.build.artifacts
-.PHONY: build.all build clean distclean lint test.init test.run test.done e2e.init e2e.run e2e.done
+.PHONY: build.all build clean distclean lint test test.init test.run test.done e2e.init e2e.run e2e.done
 
 # ====================================================================================
 # Release Targets


### PR DESCRIPTION
Ran into a problem because I had a binary called test in my project.

Problem:
> make test
make: `test' is up to date.

Solution:
Add test to correctly be a .PHONY target so it doesn't look for a file called test ever.