### PR TITLE
Fix go.vendor.check to depend on DEP

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -170,7 +170,7 @@ go.vendor.lite: $(DEP)
 		$(MAKE) vendor; \
 	fi
 
-go.vendor.check:
+go.vendor.check: $(DEP)
 	@$(INFO) checking if vendor deps changed
 	@$(DEP) ensure || $(FAIL)
 	@if ! git diff --exit-code --name-only Gopkg.lock &> /dev/null; then \


### PR DESCRIPTION
Circle ci is failing with latest build submodule, because dep is not installed. Making vendor check depend on dep.

```
#!/bin/bash -eo pipefail
./build/run make vendor.check
./build/run make -j$(nproc) build.all
==== building the cross container (this could take minutes the first time)
^@^@16:57:27 [ .. ] checking if vendor deps changed
/bin/bash: /home/upbound/go/src/github.com/upbound/upbound-api/.cache/tools/linux_amd64/dep-v0.4.1: No such file or directory
16:57:27 [FAIL]
build/makelib/golang.mk:174: recipe for target 'go.vendor.check' failed
make: *** [go.vendor.check] Error 1
Exited with code 1
```
