### PR TITLE
Update `dep` to `v0.5.0` 

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -65,7 +65,7 @@ endif
 GOPATH := $(shell go env GOPATH)
 
 # setup tools used during the build
-DEP_VERSION=v0.4.1
+DEP_VERSION=v0.5.0
 DEP := $(TOOLS_HOST_DIR)/dep-$(DEP_VERSION)
 GOLINT := $(TOOLS_HOST_DIR)/golint
 GOJUNIT := $(TOOLS_HOST_DIR)/go-junit-report


### PR DESCRIPTION
[v0.5.0](https://github.com/golang/dep/releases/tag/v0.5.0) was released back in July.

`v0.4.1` results in `Gopkg.lock` that differs from the latest `go dep`. And chances are if you ran `go get -u github.com/golang/dep/cmd/dep` you already have `dep` which is "inconsistent" with `v0.4.1`. 

Running `v0.4.1` in `build` and `dep ensure` with more recent version will result in diff in `Gopkg.lock` which, if accidentally committed will result in `dirty` tag.

