### PR TITLE
don't dep ensure before dep check

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -172,8 +172,7 @@ go.vendor.lite: $(DEP)
 
 go.vendor.check: $(DEP)
 	@$(INFO) checking if vendor deps changed
-	@$(DEP) ensure || $(FAIL)
-	@$(DEP) check || $(FAIL)
+	@$(DEP) check -skip-vendor || $(FAIL)
 	@$(OK) vendor deps have not changed
 
 go.vendor: $(DEP)


### PR DESCRIPTION
running `dep ensure` prior to `dep check` invalidates the check so we will have a new Gopkg.lock. Instead we run `dep check -skip-vendor` to check that the go source code, Gopkg.toml, and Gopkg.lock are all in sync. if they're not it will fail and show what is not in sync.