### PR TITLE
add support for setting parallel in go tests

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -133,6 +133,12 @@ endif
 OS := $(word 1, $(subst _, ,$(PLATFORM)))
 ARCH := $(word 2, $(subst _, ,$(PLATFORM)))
 
+ifeq ($(HOSTOS),darwin)
+NPROCS := $(shell sysctl -n hw.ncpu)
+else
+NPROCS := $(shell nproc)
+endif
+
 # ====================================================================================
 # Setup directories and paths
 

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -24,6 +24,7 @@ GO_BUILDFLAGS ?=
 GO_LDFLAGS ?=
 GO_TAGS ?=
 GO_TEST_FLAGS ?=
+GO_TEST_SUITE ?=
 
 # ====================================================================================
 # Setup go environment
@@ -54,12 +55,12 @@ GOHOSTARCH := $(HOSTARCH)
 GO_PACKAGES := $(foreach t,$(GO_SUBDIRS),$(GO_PROJECT)/$(t)/...)
 GO_INTEGRATION_TEST_PACKAGES := $(foreach t,$(GO_INTEGRATION_TESTS_SUBDIRS),$(GO_PROJECT)/$(t)/integration)
 
-ifneq ($(GO_TEST_SUITE),)
-GO_TEST_FLAGS += -run '$(GO_TEST_SUITE)'
+ifneq ($(GO_TEST_PARALLEL),)
+GO_TEST_FLAGS += -p $(GO_TEST_PARALLEL)
 endif
 
-ifneq ($(GO_TEST_FILTER),)
-TEST_FILTER_PARAM := -testify.m '$(GO_TEST_FILTER)'
+ifneq ($(GO_TEST_SUITE),)
+GO_TEST_FLAGS += -run '$(GO_TEST_SUITE)'
 endif
 
 GOPATH := $(shell go env GOPATH)


### PR DESCRIPTION
this add support for passing `-p n` to `go test` and also a variable for the number of CPU cores on the host machine.