### PR TITLE
Fix BRANCH_NAME so it works even with a detached HEAD.

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -83,7 +83,7 @@ override COMMIT_HASH := $(shell git rev-parse HEAD)
 endif
 
 ifeq ($(origin BRANCH_NAME), undefined)
-BRANCH_NAME := $(shell git branch | grep \* | cut -d ' ' -f2)
+BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD)
 endif
 
 REMOTE_NAME ?= origin

--- a/makelib/docs.mk
+++ b/makelib/docs.mk
@@ -27,7 +27,7 @@ ifndef DOCS_GIT_REPO
 $(error DOCS_GIT_REPO must be defined)
 endif
 
-DOCS_VERSION := $(shell echo $(BRANCH_NAME) | sed -E "s/^release\-([0-9]+)\.([0-9]+)$$/v\1.\2/g")
+DOCS_VERSION := $(shell echo "$(BRANCH_NAME)" | sed -E "s/^release\-([0-9]+)\.([0-9]+)$$/v\1.\2/g")
 DOCS_WORK_DIR := $(WORK_DIR)/docs-repo
 DOCS_VERSION_DIR := $(DOCS_WORK_DIR)/$(DEST_DOCS_DIR)/$(DOCS_VERSION)
 


### PR DESCRIPTION
Defensively quote BRANCH_NAME so it is more safe.