### PR TITLE
build: updated build.vars to include helm tool location

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -241,7 +241,7 @@ endef
 # ====================================================================================
 # This is a special target used to support the build container
 
-build.vars:
+common.buildvars:
 	@echo PROJECT_NAME=$(PROJECT_NAME)
 	@echo PROJECT_REPO=$(PROJECT_REPO)
 	@echo BUILD_HOST=$(HOSTNAME)
@@ -250,6 +250,8 @@ build.vars:
 	@echo OUTPUT_DIR=$(OUTPUT_DIR)
 	@echo WORK_DIR=$(WORK_DIR)
 	@echo CACHE_DIR=$(CACHE_DIR)
+
+build.vars: common.buildvars
 
 # ====================================================================================
 # Common Targets - Build and Test workflow

--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -114,6 +114,10 @@ helm.promote: $(HELM_HOME)
 # ====================================================================================
 # Common Targets
 
+helm.buildvars:
+	@echo HELM=$(HELM)
+
+build.vars: helm.buildvars
 build.init: helm.prepare helm.lint
 build.check: helm.dep
 build.artifacts: helm.build


### PR DESCRIPTION
This update will allow the build scripts in the crossplane project to export the location of the helm tool in the .cache directory.

Signed-off-by: HashedDan <daniel.mangum@slalom.com>