### PR TITLE
Gate Go builds on the linter

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -102,9 +102,17 @@ GO_BIN_DIR := $(abspath $(OUTPUT_DIR)/bin)
 GO_OUT_DIR := $(GO_BIN_DIR)/$(PLATFORM)
 GO_TEST_DIR := $(abspath $(OUTPUT_DIR)/tests)
 GO_TEST_OUTPUT := $(GO_TEST_DIR)/$(PLATFORM)
+GO_LINT_DIR := $(abspath $(OUTPUT_DIR)/lint)
+GO_LINT_OUTPUT := $(GO_LINT_DIR)/$(PLATFORM)
 
 ifeq ($(GOOS),windows)
 GO_OUT_EXT := .exe
+endif
+
+# Detect when we're running in CI and output checkstyle XML at lint time rather
+# than human readable output.
+ifeq ($(RUNNING_IN_CI),true)
+GO_LINT_ARGS := --out-format=checkstyle > $(GO_LINT_OUTPUT)/checkstyle.xml
 endif
 
 # NOTE: the install suffixes are matched with the build container to speed up the
@@ -168,7 +176,8 @@ go.test.integration: $(GOJUNIT)
 
 go.lint: $(GOLANGCILINT)
 	@$(INFO) golangci-lint
-	@$(GOLANGCILINT) run || $(FAIL)
+	@mkdir -p $(GO_LINT_OUTPUT)
+	@$(GOLANGCILINT) run $(GO_LINT_ARGS) || $(FAIL)
 	@$(OK) golangci-lint
 
 go.vet:

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -235,12 +235,12 @@ go.generate:
 # Common Targets
 
 build.init: go.init
-build.check: go.fmt
-build.check.platform: go.vet
+build.check: go.lint
 build.code.platform: go.build
 clean: go.clean
 distclean: go.distclean
-lint: go.lint
+lint.init: go.init
+lint.run: go.lint
 test.run: go.test.unit
 
 # ====================================================================================

--- a/run
+++ b/run
@@ -153,6 +153,7 @@ docker run \
     -e GITHUB_TOKEN \
     -e VERSION \
     -e CHANNEL \
+    -e RUNNING_IN_CI \
     -v ${PWD}/_output:${BUILDER_HOME}/go/bin \
     ${TTY_ARGS} \
     ${KUBE_ARGS} \


### PR DESCRIPTION
This PR does two things:

Causes `golint-ci` to output checkstyle XML to a file (as opposed to human readable output to the terminal) when the environment variable `RUNNING_IN_CI` is true. I considered automatically attempting to detect a TTY from within `make`, as well as testing for the presence of the `JENKINS_URL` environment variable. I settled on being as explicit as possible - i.e. depending on the CI runner (in our case Jenkins) to set `RUNNING_IN_CI=true`

Configures `make build` to run `make go.lint` (i.e. `golangci-lint`) instead of running `make go.fmt` and `make go.vet`. `golangci-lint` runs many linters, including `gofmt` and `go vet`, and runs fast. This change means builds will not pass if the linter fails, and means we're not invoking the same linters multiple times. Note that in this context we were running `gofmt` as a linter - i.e. running it in diff mode - rather than actually using it to format our files in place.