### PR TITLE
Install a concrete version of golangci-lint

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -288,12 +288,12 @@ help-special: go.help
 # Tools install targets
 
 $(DEP):
-	@$(INFO) installing dep $(HOSTOS)-$(HOSTARCH)
+	@$(INFO) installing dep-$(DEP_VERSION) $(HOSTOS)-$(HOSTARCH)
 	@mkdir -p $(TOOLS_HOST_DIR)/tmp-dep || $(FAIL)
 	@curl -fsSL -o $(DEP) https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-$(HOSTOS)-$(HOSTARCH) || $(FAIL)
 	@chmod +x $(DEP) || $(FAIL)
 	@rm -fr $(TOOLS_HOST_DIR)/tmp-dep
-	@$(OK) installing dep $(HOSTOS)-$(HOSTARCH)
+	@$(OK) installing dep-$(DEP_VERSION) $(HOSTOS)-$(HOSTARCH)
 
 $(GOLANGCILINT):
 	@$(INFO) installing golangci-lint-v$(GOLANGCILINT_VERSION) $(HOSTOS)-$(HOSTARCH)

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -82,7 +82,6 @@ GOPATH := $(shell go env GOPATH)
 # setup tools used during the build
 DEP_VERSION=v0.5.0
 DEP := $(TOOLS_HOST_DIR)/dep-$(DEP_VERSION)
-GOLANGCILINT := $(TOOLS_HOST_DIR)/golangci-lint
 GOJUNIT := $(TOOLS_HOST_DIR)/go-junit-report
 GOCOVER_COBERTURA := $(TOOLS_HOST_DIR)/gocover-cobertura
 GOIMPORTS := $(TOOLS_HOST_DIR)/goimports
@@ -99,6 +98,11 @@ GOFMT := $(shell which gofmt)
 else
 GOFMT := $(TOOLS_HOST_DIR)/gofmt$(GOFMT_VERSION)
 endif
+
+# We use a consistent version of golangci-lint to ensure everyone gets the same
+# linters.
+GOLANGCILINT_VERSION := 1.15.0
+GOLANGCILINT := $(TOOLS_HOST_DIR)/golangci-lint-v$(GOLANGCILINT_VERSION)
 
 GO_BIN_DIR := $(abspath $(OUTPUT_DIR)/bin)
 GO_OUT_DIR := $(GO_BIN_DIR)/$(PLATFORM)
@@ -297,11 +301,12 @@ $(DEP):
 	@$(OK) installing dep $(HOSTOS)-$(HOSTARCH)
 
 $(GOLANGCILINT):
-	@$(INFO) installing golangci-lint
+	@$(INFO) installing golangci-lint-v$(GOLANGCILINT_VERSION) $(HOSTOS)-$(HOSTARCH)
 	@mkdir -p $(TOOLS_HOST_DIR)/tmp-golangci-lint || $(FAIL)
-	@GOPATH=$(TOOLS_HOST_DIR)/tmp-golangci-lint GOBIN=$(TOOLS_HOST_DIR) $(GOHOST) get -u github.com/golangci/golangci-lint/cmd/golangci-lint || rm -fr $(TOOLS_HOST_DIR)/tmp-golangci-lint || $(FAIL)
+	@curl -fsSL https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCILINT_VERSION)/golangci-lint-$(GOLANGCILINT_VERSION)-$(HOSTOS)-$(HOSTARCH).tar.gz | tar -xz --strip-components=1 -C $(TOOLS_HOST_DIR)/tmp-golangci-lint || $(FAIL)
+	@mv $(TOOLS_HOST_DIR)/tmp-golangci-lint/golangci-lint $(GOLANGCILINT) || $(FAIL)
 	@rm -fr $(TOOLS_HOST_DIR)/tmp-golangci-lint
-	@$(OK) installing golangci-lint
+	@$(OK) installing golangci-lint-v$(GOLANGCILINT_VERSION) $(HOSTOS)-$(HOSTARCH)
 
 $(GOFMT):
 	@$(INFO) installing gofmt$(GOFMT_VERSION)

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -290,12 +290,7 @@ help-special: go.help
 $(DEP):
 	@$(INFO) installing dep $(HOSTOS)-$(HOSTARCH)
 	@mkdir -p $(TOOLS_HOST_DIR)/tmp-dep || $(FAIL)
-	@if [ "$(GOHOSTARCH)" = "arm64" ]; then\
-		GOPATH=$(TOOLS_HOST_DIR)/tmp-dep GOBIN=$(TOOLS_HOST_DIR) $(GOHOST) get -u github.com/golang/dep/cmd/dep || $(FAIL) ;\
-		mv $(TOOLS_HOST_DIR)/dep $@ || $(FAIL);\
-	else \
-		curl -fsSL -o $(DEP) https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-$(HOSTOS)-$(HOSTARCH) || $(FAIL);\
-	fi
+	@curl -fsSL -o $(DEP) https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-$(HOSTOS)-$(HOSTARCH) || $(FAIL)
 	@chmod +x $(DEP) || $(FAIL)
 	@rm -fr $(TOOLS_HOST_DIR)/tmp-dep
 	@$(OK) installing dep $(HOSTOS)-$(HOSTARCH)


### PR DESCRIPTION
```
$ make distclean
09:39:10 [ .. ] cleaning images for build-3af134bd
09:39:10 [ OK ] cleaning images for build-3af134bd

$ make lint
09:39:12 [ .. ] installing helm darwin-amd64
09:39:19 [ OK ] installing helm darwin-amd64
Creating /Users/negz/control/go/src/github.com/crossplaneio/crossplane/.work/helm/repository                                                                               
Creating /Users/negz/control/go/src/github.com/crossplaneio/crossplane/.work/helm/repository/cache                                                                         
Creating /Users/negz/control/go/src/github.com/crossplaneio/crossplane/.work/helm/repository/local                                                                         
Creating /Users/negz/control/go/src/github.com/crossplaneio/crossplane/.work/helm/plugins                                                                                  
Creating /Users/negz/control/go/src/github.com/crossplaneio/crossplane/.work/helm/starters                                                                                 
Creating /Users/negz/control/go/src/github.com/crossplaneio/crossplane/.work/helm/cache/archive                                                                            
Creating /Users/negz/control/go/src/github.com/crossplaneio/crossplane/.work/helm/repository/repositories.yaml                                                             
Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com
Adding local repo with URL: http://127.0.0.1:8879/charts
$HELM_HOME has been configured at /Users/negz/control/go/src/github.com/crossplaneio/crossplane/.work/helm.                                                                
Not installing Tiller due to 'client-only' flag having been set
Happy Helming!
==> Linting /Users/negz/control/go/src/github.com/crossplaneio/crossplane/cluster/charts/crossplane                                                                        
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, no failures
09:39:23 [ .. ] installing dep darwin-amd64
09:39:25 [ OK ] installing dep darwin-amd64
09:39:25 [ .. ] dep ensure
09:39:37 [ OK ] dep ensure
09:39:37 [ .. ] installing golangci-lint-v1.15.0 darwin-amd64
09:39:39 [ OK ] installing golangci-lint-v1.15.0 darwin-amd64
09:39:39 [ .. ] golangci-lint
09:39:52 [ OK ] golangci-lint

$ ls .cache/tools/darwin_amd64/
dep-v0.5.0*             golangci-lint-v1.15.0*  helm-v2.10.0*

$ .cache/tools/darwin_amd64/golangci-lint-v1.15.0 --version
golangci-lint has version 1.15.0 built from 901cf25 on 2019-02-18T08:22:26Z
```