### PR TITLE
Build using Go 1.12

### DIFF
--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -44,7 +44,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 
 # ------------------------------------------------------------------------------------------------
 # Go support
-RUN GO_VERSION=1.11 && \
+RUN GO_VERSION=1.12 && \
     GO_HASH=b3fcf280ff86558e0559e185b601c9eade0fd24c900b4c63cd14d1d38613e499 && \
     curl -fsSL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz -o golang.tar.gz && \
     echo "${GO_HASH}  golang.tar.gz" | sha256sum -c - && \

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -55,7 +55,7 @@ GO_LDFLAGS += -s -w
 endif
 
 # supported go versions
-GO_SUPPORTED_VERSIONS ?= 1.7|1.8|1.9|1.10|1.11
+GO_SUPPORTED_VERSIONS ?= 1.7|1.8|1.9|1.10|1.11|1.12
 
 # set GOOS and GOARCH
 GOOS := $(OS)


### PR DESCRIPTION
I've built Crossplane by running `GO_SUPPORTED_VERSIONS=1.12 make build` with Go 1.12.1 and confirmed it starts and runs on my minikube.

Signed-off-by: Nic Cope <negz@rk0n.org>