### PR TITLE
Updating kubebuilder to 1.0.8, new go targets

### DIFF
--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -45,7 +45,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 # ------------------------------------------------------------------------------------------------
 # Go support
 RUN GO_VERSION=1.12 && \
-    GO_HASH=b3fcf280ff86558e0559e185b601c9eade0fd24c900b4c63cd14d1d38613e499 && \
+    GO_HASH=750a07fef8579ae4839458701f4df690e0b20b8bcce33b437e4df89c451b6f13 && \
     curl -fsSL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz -o golang.tar.gz && \
     echo "${GO_HASH}  golang.tar.gz" | sha256sum -c - && \
     tar -C /usr/local -xzf golang.tar.gz && \

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -166,6 +166,11 @@ go.test.unit: $(GOJUNIT) $(GOCOVER_COBERTURA)
 	@$(GOCOVER_COBERTURA) < $(GO_TEST_OUTPUT)/coverage.txt > $(GO_TEST_OUTPUT)/coverage.xml
 	@$(OK) go test unit-tests
 
+go.test.unit.nocov:
+	@$(INFO) go test unit-tests without coverage
+	@CGO_ENABLED=0 $(GOHOST) test $(ARGS) $(GO_TEST_FLAGS) $(GO_STATIC_FLAGS) $(GO_PACKAGES) || $(FAIL)
+	@$(OK) go test unit-tests without coverage
+
 # Depends on go.test.unit, but is only run in CI with a valid token after unit-testing is complete
 # DO NOT run locally.
 go.test.codecov:
@@ -196,6 +201,11 @@ go.fmt: $(GOFMT)
 	@$(INFO) go fmt
 	@gofmt_out=$$($(GOFMT) -s -d -e $(GO_SUBDIRS) $(GO_INTEGRATION_TESTS_SUBDIRS) 2>&1) && [ -z "$${gofmt_out}" ] || (echo "$${gofmt_out}" 1>&2; $(FAIL))
 	@$(OK) go fmt
+
+go.fmt.simplify: $(GOFMT)
+	@$(INFO) gofmt simplify
+	@$(GOFMT) -l -s -w $(GO_SUBDIRS) || $(FAIL)
+	@$(OK) gofmt simplify
 
 go.imports: $(GOIMPORTS)
 	@$(INFO) goimports
@@ -267,13 +277,14 @@ generate codegen: go.generate
 
 define GO_HELPTEXT
 Go Targets:
-    generate       Runs go code generation.
-    fmt            Checks go source code for formatting issues.
-    vendor         Updates vendor packages.
-    vendor.check   Fail the build if vendor packages have changed.
-    vendor.update  Update vendor dependencies.
-    vet            Checks go source code and reports suspicious constructs.
-
+    generate        Runs go code generation.
+    fmt             Checks go source code for formatting issues.
+    fmt.simplify    Format, simplify, update source files.
+    vendor          Updates vendor packages.
+    vendor.check    Fail the build if vendor packages have changed.
+    vendor.update   Update vendor dependencies.
+    vet             Checks go source code and reports suspicious constructs.
+    test.unit.nocov Runs unit tests without coverage (faster for iterative development)
 endef
 export GO_HELPTEXT
 

--- a/makelib/kubebuilder.mk
+++ b/makelib/kubebuilder.mk
@@ -16,7 +16,7 @@
 # Options
 
 # the version of kubebuilder to use
-KUBEBUILDER_VERSION ?= 1.0.4
+KUBEBUILDER_VERSION ?= 1.0.8
 KUBEBUILDER := $(TOOLS_HOST_DIR)/kubebuilder-$(KUBEBUILDER_VERSION)
 
 # these are use by the kube builder test harness
@@ -35,7 +35,8 @@ test.init: $(KUBEBUILDER)
 
 define KUBEBULDER_HELPTEXT
 Kubebuilder Targets:
-    codegen      run code generation
+    bin        run kubebuilder binary, pass args by setting ARGS=""
+    codegen    run code generation
 
 endef
 export KUBEBULDER_HELPTEXT
@@ -45,18 +46,21 @@ kubebuilder.help:
 
 help-special: kubebuilder.help
 
-.PHONY: codegen kubebuilder.help
+kubebuilder.bin: $(KUBEBUILDER)
+	@$(KUBEBUILDER)/kubebuilder $(ARGS)
+
+.PHONY: codegen kubebuilder.help kubebuilder.bin
 
 # ====================================================================================
 # tools
 
 # kubebuilder download and install
 $(KUBEBUILDER):
-	@$(INFO) installing kubebuilder
+	@$(INFO) installing kubebuilder $(KUBEBUILDER_VERSION)
 	@mkdir -p $(TOOLS_HOST_DIR)/tmp || $(FAIL)
 	@curl -fsSL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v$(KUBEBUILDER_VERSION)/kubebuilder_$(KUBEBUILDER_VERSION)_$(GOHOSTOS)_$(GOHOSTARCH).tar.gz | tar -xz -C $(TOOLS_HOST_DIR)/tmp  || $(FAIL)
 	@mv $(TOOLS_HOST_DIR)/tmp/kubebuilder_$(KUBEBUILDER_VERSION)_$(GOHOSTOS)_$(GOHOSTARCH)/bin $(KUBEBUILDER) || $(FAIL)
 	@rm -fr $(TOOLS_HOST_DIR)/tmp
-	@$(OK) installing kubebuilder
+	@$(OK) installing kubebuilder $(KUBEBUILDER_VERSION)
 
 


### PR DESCRIPTION
- New targets:
  - go.test.unit.nocov
  - go.fmt.simplify
  - kubebuilder.bin

Signed-off-by: Sam Leavens <rbwsam@gmail.com>