### PR TITLE
Ensure vendor exists before running Go tests

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -264,6 +264,7 @@ clean: go.clean
 distclean: go.distclean
 lint.init: go.init
 lint.run: go.lint
+test.init: go.init
 test.run: go.test.unit
 
 # ====================================================================================


### PR DESCRIPTION
I just ran `make distclean && make test` on Crossplane and the tests failed due to missing vendored dependencies.

Disclaimer: I made this edit via the web interface so I haven't actually run it, but expect it to work.