### PR TITLE
Initialise Go dependencies before running tests

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -264,6 +264,7 @@ clean: go.clean
 distclean: go.distclean
 lint.init: go.init
 lint.run: go.lint
+test.init: go.init
 test.run: go.test.unit
 
 # ====================================================================================


### PR DESCRIPTION
I just ran `make distclean && make test` on Crossplane and the tests failed due to the vendor directory not existing.