### PR TITLE
update golangci-lint to 1.17.1

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -102,7 +102,7 @@ endif
 
 # We use a consistent version of golangci-lint to ensure everyone gets the same
 # linters.
-GOLANGCILINT_VERSION := 1.15.0
+GOLANGCILINT_VERSION := 1.17.1
 GOLANGCILINT := $(TOOLS_HOST_DIR)/golangci-lint-v$(GOLANGCILINT_VERSION)
 
 GO_BIN_DIR := $(abspath $(OUTPUT_DIR)/bin)


### PR DESCRIPTION
Align golangci-lint with the latest released version so users working
with opinionated IDEs aren't suprised by linting errors that haven't
been surfaced through the build system.

Signed-off-by: Marques Johansson <marques@upbound.io>