### PR TITLE
adding HOSTOS and HOSTARCH to build.vars

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -250,6 +250,8 @@ common.buildvars:
 	@echo OUTPUT_DIR=$(OUTPUT_DIR)
 	@echo WORK_DIR=$(WORK_DIR)
 	@echo CACHE_DIR=$(CACHE_DIR)
+	@echo HOSTOS=$(HOSTOS)
+	@echo HOSTARCH=$(HOSTARCH)
 
 build.vars: common.buildvars
 


### PR DESCRIPTION
`HOSTOS` and `HOSTARCH` values are hardcoded in `minikube.sh` and `integration_tests.sh`. Adding these to `build.vars` target, so it could be read from there, rather than being hardcoded.

Signed-off-by: soorena776 <javad@upbound.io>