### PR TITLE
reduce golangci-lint overhead for jenkins worker

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -117,8 +117,10 @@ GO_OUT_EXT := .exe
 endif
 
 ifeq ($(RUNNING_IN_CI),true)
+# Reduce concurrency to reduce RAM requirements on jenkins worker nodes
+# increase deadline to 3m (from default 1m, crossplane default 2m) to potentially compensate for less concurrency
 # Output checkstyle XML rather than human readable output.
-GO_LINT_ARGS := --out-format=checkstyle > $(GO_LINT_OUTPUT)/checkstyle.xml
+GO_LINT_ARGS := --concurrency=1 --deadline=3m0s --out-format=checkstyle > $(GO_LINT_OUTPUT)/checkstyle.xml
 
 # Output verbose tests that can be parsed into JUnit XML.
 GO_TEST_FLAGS += -v
@@ -192,7 +194,7 @@ go.test.integration: $(GOJUNIT)
 go.lint: $(GOLANGCILINT)
 	@$(INFO) golangci-lint
 	@mkdir -p $(GO_LINT_OUTPUT)
-	@$(GOLANGCILINT) run $(GO_LINT_ARGS) || $(FAIL)
+	@LINT_GOGC=20 $(GOLANGCILINT) run $(GO_LINT_ARGS) || $(FAIL)
 	@$(OK) golangci-lint
 
 go.vet:


### PR DESCRIPTION
The changes suggested here appear to improve the overhead of the build process with the latest golangci-lint.
https://github.com/golangci/golangci-lint/issues/337#issuecomment-510136513

With 1.17.1 of golangci-lint we regularly see 10GB of RAM consumed while linting in local
testing.

Prior to the bump to 1.17.1, golangci-lint 1.15 was taking 6-8GB of RAM and
completing in 10s in local testing.

With the reduction in overhead to golangci-lint that this PR introduces,
linting consumes between 8-9GB of ram and completes in 30s using the same
environment.

The Crossplane Jenkins worker node has only 10GB of RAM available. 

The intent here is to continue using latest `golangci-lint` with the
current Jenkins configuration (not increasing node memory), sacrificing some time.  Additional
measures can be made, such as using `--fast` tests only or further increasing the
`LINT_GOGC` value.  Ultimately we may prefer to revert to `golangci-lint` v1.15.0 and wait for a version that doesn't inflate the RAM used so significantly.

https://github.com/golangci/golangci-lint#configuration
https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint

Relates to: https://github.com/crossplaneio/crossplane/pull/577

Closes #71