### PR TITLE
`fmt` target is currently calling `go.imports`

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -272,7 +272,8 @@ test.run: go.test.unit
 # ====================================================================================
 # Special Targets
 
-fmt: go.imports
+fmt: go.fmt
+fmt.simplify: go.fmt.simplify
 vendor: go.vendor
 vendor.check: go.vendor.check
 vendor.update: go.vendor.update


### PR DESCRIPTION
Currently the `fmt` target is actually calling the `go.imports`. I also noticed that the `fmt.simplify` target is mentioned in the `make help` but doesn't exist.  