### PR TITLE
Revert "update golangci-lint to 1.17.1"

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -102,7 +102,7 @@ endif
 
 # We use a consistent version of golangci-lint to ensure everyone gets the same
 # linters.
-GOLANGCILINT_VERSION := 1.17.1
+GOLANGCILINT_VERSION := 1.15.0
 GOLANGCILINT := $(TOOLS_HOST_DIR)/golangci-lint-v$(GOLANGCILINT_VERSION)
 
 GO_BIN_DIR := $(abspath $(OUTPUT_DIR)/bin)


### PR DESCRIPTION
This reverts commit a45f23747b04ae1bdb2ad3edf1dfbfffbd1e5cbd.

golangci-lint 1.17.1 increased the memory footprint of the CI/CD
processes substantially.

This PR is an alternative to:

* Increasing the RAM on the Jenkins Worker Node
* Decreasing the parallelism, increasing the GC rate, increasing the
lint timeout as is handled by upbound/build#68

Closes #68 

Signed-off-by: Marques Johansson <marques@upbound.io>