### PR TITLE
helm: update helm version to v2.15.1

### DIFF
--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -40,7 +40,7 @@ HELM_HOME := $(abspath $(WORK_DIR)/helm)
 export HELM_HOME
 
 # helm tool version
-HELM_VERSION := v2.10.0
+HELM_VERSION := v2.15.1
 HELM := $(TOOLS_HOST_DIR)/helm-$(HELM_VERSION)
 
 # remove the leading `v` for helm chart versions
@@ -92,7 +92,7 @@ $(HELM_INDEX): $(HELM_HOME) $(HELM_OUTPUT_DIR)
 
 helm.build: $(HELM_INDEX)
 
-helm.clean: 
+helm.clean:
 	@rm -fr $(HELM_OUTPUT_DIR)
 
 # ====================================================================================


### PR DESCRIPTION
This PR updates the version of the helm tool to v2.15.1.  We were using a fairly old version of v2.10.0 which has issues with post-install hooks.