### PR TITLE
go: update to 1.13

### DIFF
--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -45,7 +45,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 # ------------------------------------------------------------------------------------------------
 # Go support
 RUN GO_VERSION=1.13 && \
-    GO_HASH=750a07fef8579ae4839458701f4df690e0b20b8bcce33b437e4df89c451b6f13 && \
+    GO_HASH=68a2297eb099d1a76097905a2ce334e3155004ec08cdea85f24527be3c48e856 && \
     curl -fsSL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz -o golang.tar.gz && \
     echo "${GO_HASH}  golang.tar.gz" | sha256sum -c - && \
     tar -C /usr/local -xzf golang.tar.gz && \

--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -44,7 +44,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 
 # ------------------------------------------------------------------------------------------------
 # Go support
-RUN GO_VERSION=1.12 && \
+RUN GO_VERSION=1.13 && \
     GO_HASH=750a07fef8579ae4839458701f4df690e0b20b8bcce33b437e4df89c451b6f13 && \
     curl -fsSL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz -o golang.tar.gz && \
     echo "${GO_HASH}  golang.tar.gz" | sha256sum -c - && \

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -56,7 +56,7 @@ GO_LDFLAGS += -s -w
 endif
 
 # supported go versions
-GO_SUPPORTED_VERSIONS ?= 1.7|1.8|1.9|1.10|1.11|1.12
+GO_SUPPORTED_VERSIONS ?= 1.7|1.8|1.9|1.10|1.11|1.12|1.13
 
 # set GOOS and GOARCH
 GOOS := $(OS)

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -102,7 +102,7 @@ endif
 
 # We use a consistent version of golangci-lint to ensure everyone gets the same
 # linters.
-GOLANGCILINT_VERSION := 1.15.0
+GOLANGCILINT_VERSION := 1.18.0
 GOLANGCILINT := $(TOOLS_HOST_DIR)/golangci-lint-v$(GOLANGCILINT_VERSION)
 
 GO_BIN_DIR := $(abspath $(OUTPUT_DIR)/bin)


### PR DESCRIPTION
Adds support for go [1.13](https://golang.org/doc/go1.13) and updates build system to use it.