### PR TITLE
Enable goproxy in build/run

### DIFF
--- a/run
+++ b/run
@@ -144,6 +144,9 @@ rsync_back() {
     fi
 }
 
+# set GOPROXY
+GOPROXY=https://proxy.golang.org
+
 docker run \
     --rm \
     -h ${BUILD_HOST} \
@@ -154,6 +157,7 @@ docker run \
     -e VERSION \
     -e CHANNEL \
     -e RUNNING_IN_CI \
+    -e GOPROXY="${GOPROXY}" \
     -v ${PWD}/_output:${BUILDER_HOME}/go/bin \
     ${TTY_ARGS} \
     ${KUBE_ARGS} \


### PR DESCRIPTION
This PR enables Go module proxy by setting in build/run by setting `GOPROXY` env var as `https://proxy.golang.org` (the Go proxy from the Go team, which is run by Google)

Using a proxy will speed up the builds and protect from transient errors like [this](https://github.com/dominikh/go-tools/issues/658) with reproducible builds. It will be enabled by default with Go v1.13. More details and advantages of using a proxy can be found here: https://arslan.io/2019/08/02/why-you-should-use-a-go-module-proxy/

I mainly need this for a case wher build fails without GOPROXY during resolving a dependency even it works when GOPROXY is set.

Signed-off-by: Hasan Turken <turkenh@gmail.com>