### PR TITLE
Update golangcilint to 1.22.2 and go to 1.13.5

### DIFF
--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -44,8 +44,8 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 
 # ------------------------------------------------------------------------------------------------
 # Go support
-RUN GO_VERSION=1.12 && \
-    GO_HASH=750a07fef8579ae4839458701f4df690e0b20b8bcce33b437e4df89c451b6f13 && \
+RUN GO_VERSION=1.13.5 && \
+    GO_HASH=512103d7ad296467814a6e3f635631bd35574cab3369a97a323c9a585ccaa569 && \
     curl -fsSL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz -o golang.tar.gz && \
     echo "${GO_HASH}  golang.tar.gz" | sha256sum -c - && \
     tar -C /usr/local -xzf golang.tar.gz && \

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -51,7 +51,7 @@ GO_LDFLAGS += -s -w
 endif
 
 # supported go versions
-GO_SUPPORTED_VERSIONS ?= 1.7|1.8|1.9|1.10|1.11|1.12
+GO_SUPPORTED_VERSIONS ?= 1.7|1.8|1.9|1.10|1.11|1.12|1.13
 
 # set GOOS and GOARCH
 GOOS := $(OS)

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -97,7 +97,7 @@ endif
 
 # We use a consistent version of golangci-lint to ensure everyone gets the same
 # linters.
-GOLANGCILINT_VERSION := 1.22.2
+GOLANGCILINT_VERSION ?= 1.22.2
 GOLANGCILINT := $(TOOLS_HOST_DIR)/golangci-lint-v$(GOLANGCILINT_VERSION)
 
 GO_BIN_DIR := $(abspath $(OUTPUT_DIR)/bin)

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -97,7 +97,7 @@ endif
 
 # We use a consistent version of golangci-lint to ensure everyone gets the same
 # linters.
-GOLANGCILINT_VERSION := 1.15.0
+GOLANGCILINT_VERSION := 1.22.2
 GOLANGCILINT := $(TOOLS_HOST_DIR)/golangci-lint-v$(GOLANGCILINT_VERSION)
 
 GO_BIN_DIR := $(abspath $(OUTPUT_DIR)/bin)

--- a/run
+++ b/run
@@ -144,6 +144,9 @@ rsync_back() {
     fi
 }
 
+# set GOPRIVATE to skip go-proxy on upbound by default - https://tip.golang.org/cmd/go/#hdr-Module_configuration_for_non_public_modules
+GOPRIVATE="github.com/upbound/*"
+
 docker run \
     --rm \
     -h ${BUILD_HOST} \
@@ -154,6 +157,7 @@ docker run \
     -e VERSION \
     -e CHANNEL \
     -e RUNNING_IN_CI \
+    -e GOPRIVATE="${GOPRIVATE}" \
     -v ${PWD}/_output:${BUILDER_HOME}/go/bin \
     ${TTY_ARGS} \
     ${KUBE_ARGS} \


### PR DESCRIPTION
I was having odd bugs showing up with trying to use helm v3 as a dependency saying it couldn't be found, like: `go: helm.sh/helm/v3@v3.0.0: unknown revision helm.sh/helm/v3.0.0`

Upgrading to go 1.13.5 seems to have resolved the issue.

Additionally to support go 1.13:
- golangcilint failed and needed an upgrade
- go proxy doesn't work with private repos, so I've added github.com/upound/* to GOPRIVATE.