### PR TITLE
Add unzip to cross image

### DIFF
--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -30,6 +30,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     rsync \
     runit \
     sudo \
+    unzip \
     zip && \
     DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -113,7 +113,8 @@ endif
 
 ifeq ($(RUNNING_IN_CI),true)
 # Output checkstyle XML rather than human readable output.
-GO_LINT_ARGS := --out-format=checkstyle > $(GO_LINT_OUTPUT)/checkstyle.xml
+# the timeout is increased to 10m, to accommodate CI machines with low resources.
+GO_LINT_ARGS := --timeout 10m0s --out-format=checkstyle > $(GO_LINT_OUTPUT)/checkstyle.xml
 
 # Output verbose tests that can be parsed into JUnit XML.
 GO_TEST_FLAGS += -v

--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -40,7 +40,7 @@ HELM_HOME := $(abspath $(WORK_DIR)/helm)
 export HELM_HOME
 
 # helm tool version
-HELM_VERSION := v2.15.1
+HELM_VERSION ?= v2.15.1
 HELM := $(TOOLS_HOST_DIR)/helm-$(HELM_VERSION)
 
 # remove the leading `v` for helm chart versions


### PR DESCRIPTION
Addresses:
- Adding the unzip command to make it possible to unzip zipped files in cross image
- Fixes: upbound/hosted-crossplane-squad#127


