### PR TITLE
Upgrading golangci-lint to fix build in go 1.14

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -96,7 +96,7 @@ endif
 
 # We use a consistent version of golangci-lint to ensure everyone gets the same
 # linters.
-GOLANGCILINT_VERSION ?= 1.22.2
+GOLANGCILINT_VERSION ?= 1.23.8
 GOLANGCILINT := $(TOOLS_HOST_DIR)/golangci-lint-v$(GOLANGCILINT_VERSION)
 
 GO_BIN_DIR := $(abspath $(OUTPUT_DIR)/bin)


### PR DESCRIPTION
Upgrading golangci-lint to fix build in go 1.14

It fixes the lint errors I got while building crossplane/crossplane and crossplane/crossplane-repos with go 1.14.

Signed-off-by: Artur Souza <artursouza.ms@outlook.com>