### PR TITLE
Expose Helm version as buildvar

### DIFF
--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -144,6 +144,7 @@ $(foreach p,$(HELM_CHARTS),$(eval $(call museum.upload,$(p))))
 
 helm.buildvars:
 	@echo HELM=$(HELM)
+	@echo HELM_VERSION=$(HELM_VERSION)
 
 build.vars: helm.buildvars
 build.init: helm.prepare helm.lint


### PR DESCRIPTION
Every time a minikube or kind is initiated, Helm image is pulled from GCR. If we expose the version, then those scripts could just pull the image once into the local and load it to the node every time from the local machine instead of downloading it every time.

Something like this would be possible in [`kind.sh up`](https://github.com/crossplane/crossplane/blob/master/cluster/local/kind.sh#L45) command:
```
docker pull gcr.io/kubernetes-helm/tiller:${HELM_VERSION}
kind load docker-image gcr.io/kubernetes-helm/tiller:${HELM_VERSION}
# Then helm init and other stuff.
```

Tested with above code snippet in `kind.sh`.