### PR TITLE
Bump cross container Go version to 1.14.4

### DIFF
--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -45,8 +45,8 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 
 # ------------------------------------------------------------------------------------------------
 # Go support
-RUN GO_VERSION=1.14 && \
-    GO_HASH=08df79b46b0adf498ea9f320a0f23d6ec59e9003660b4c9c1ce8e5e2c6f823ca && \
+RUN GO_VERSION=1.14.4 && \
+    GO_HASH=aed845e4185a0b2a3c3d5e1d0a35491702c55889192bb9c30e67a3de6849c067 && \
     curl -fsSL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz -o golang.tar.gz && \
     echo "${GO_HASH}  golang.tar.gz" | sha256sum -c - && \
     tar -C /usr/local -xzf golang.tar.gz && \


### PR DESCRIPTION
This updates the cross container go version to include a
workaround for the linux kernel bug described in this
issue https://github.com/golang/go/issues/37436

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>