### PR TITLE
Fix test result

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -174,7 +174,7 @@ ifeq ($(GO_NOCOV),true)
 else
 	@mkdir -p $(GO_TEST_OUTPUT)
 	@CGO_ENABLED=0 $(GOHOST) test -i -cover $(GO_STATIC_FLAGS) $(GO_PACKAGES) || $(FAIL)
-	@CGO_ENABLED=0 $(GOHOST) test -covermode=count -coverprofile=$(GO_TEST_OUTPUT)/coverage.txt $(GO_TEST_FLAGS) $(GO_STATIC_FLAGS) $(GO_PACKAGES) 2>&1 | tee $(GO_TEST_OUTPUT)/unit-tests.log || $(FAIL)
+	@CGO_ENABLED=0 $(GOHOST) test -v -covermode=count -coverprofile=$(GO_TEST_OUTPUT)/coverage.txt $(GO_TEST_FLAGS) $(GO_STATIC_FLAGS) $(GO_PACKAGES) 2>&1 | tee $(GO_TEST_OUTPUT)/unit-tests.log || $(FAIL)
 	@cat $(GO_TEST_OUTPUT)/unit-tests.log | $(GOJUNIT) -set-exit-code > $(GO_TEST_OUTPUT)/unit-tests.xml || $(FAIL)
 	@$(GOCOVER_COBERTURA) < $(GO_TEST_OUTPUT)/coverage.txt > $(GO_TEST_OUTPUT)/coverage.xml
 endif


### PR DESCRIPTION
Logs during test cause change in structure of `unit-tests.log` file and some test results might be ignored and not included to `unit-tests.xml`. It is used to checking result of running tests, so even if some tests are failed exit code of `make test` is `0`. Because of that our circleci build missed failed tests too and marked build as passed. 
Adding  `-v` streams logs output as it happens, rather than adds to the end of test run. I've tried to run build with these changes and it fixed circleci build (it failed for failed tests)