### PR TITLE
[Do not Merge] helm: add logs for target helm home

### DIFF
--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -56,8 +56,10 @@ HELM_CHART_VERSION := $(VERSION:v%=%)
 # Helm Targets
 
 $(HELM_HOME): $(HELM)
+	@$(INFO) helm home and init
 	@mkdir -p $(HELM_HOME)
 	@$(HELM) init -c
+	@$(OK) helm home and init
 
 $(HELM_OUTPUT_DIR):
 	@mkdir -p $(HELM_OUTPUT_DIR)
@@ -65,7 +67,7 @@ $(HELM_OUTPUT_DIR):
 define helm.chart
 $(HELM_OUTPUT_DIR)/$(1)-$(HELM_CHART_VERSION).tgz: $(HELM_HOME) $(HELM_OUTPUT_DIR) $(shell find $(HELM_CHARTS_DIR)/$(1) -type f)
 	@$(INFO) helm package $(1) $(HELM_CHART_VERSION)
-	@$(HELM) package --version $(HELM_CHART_VERSION) --app-version $(HELM_CHART_VERSION) -d $(HELM_OUTPUT_DIR) $(abspath $(HELM_CHARTS_DIR)/$(1))
+	@$(HELM) package --version $(HELM_CHART_VERSION) --app-version $(HELM_CHART_VERSION) -d $(HELM_OUTPUT_DIR) $(abspath $(HELM_CHARTS_DIR)/$(1)) --save false
 	@$(OK) helm package $(1) $(HELM_CHART_VERSION)
 
 helm.prepare.$(1): $(HELM_HOME)


### PR DESCRIPTION
Trying to debug following annoying sporadic build bug, which I suspect to be related to helm targets not running well in parallel (e.g. -j8)

```
20:17:17 [ OK ] helm package maincluster-operator 0.14.0-alpha1.25.gdde3e70
20:17:17 [ .. ] helm package crossplane-cluster-velero 0.14.0-alpha1.25.gdde3e70
Successfully packaged chart and saved it to: /home/upbound/go/src/github.com/upbound/wesaas/_output/charts/hostcluster-base-0.14.0-alpha1.25.gdde3e70.tgz
Successfully packaged chart and saved it to: /home/upbound/go/src/github.com/upbound/wesaas/_output/charts/hostcluster-tiers-gcp-0.14.0-alpha1.25.gdde3e70.tgz
Successfully packaged chart and saved it to: /home/upbound/go/src/github.com/upbound/wesaas/_output/charts/hostcluster-tiers-localdev-0.14.0-alpha1.25.gdde3e70.tgz
WARNING: Deprecated index file format. Try 'helm repo update'
Error: no API version specified
build/makelib/helm.mk:92: recipe for target '/home/upbound/go/src/github.com/upbound/wesaas/_output/charts/hostcluster-tiers-localdev-0.14.0-alpha1.25.gdde3e70.tgz' failed
make[1]: *** [/home/upbound/go/src/github.com/upbound/wesaas/_output/charts/hostcluster-tiers-localdev-0.14.0-alpha1.25.gdde3e70.tgz] Error 1
make[1]: *** Waiting for unfinished jobs....
20:17:17 [ OK ] helm package hostcluster-base 0.14.0-alpha1.25.gdde3e70
20:17:17 [ OK ] helm package hostcluster-tiers-gcp 0.14.0-alpha1.25.gdde3e70
Successfully packaged chart and saved it to: /home/upbound/go/src/github.com/upbound/wesaas/_output/charts/crossplane-cluster-velero-0.14.0-alpha1.25.gdde3e70.tgz
20:17:17 [ OK ] helm package crossplane-cluster-velero 0.14.0-alpha1.25.gdde3e70
build/makelib/common.mk:302: recipe for target 'build.all' failed
make: *** [build.all] Error 2
 
Exited with code exit status 1 
```
Signed-off-by: Hasan Turken <turkenh@gmail.com>