### PR TITLE
Helm: fix race condition for parallel package's

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -114,9 +114,6 @@ ifeq ($(RUNNING_IN_CI),true)
 # Output checkstyle XML rather than human readable output.
 # the timeout is increased to 10m, to accommodate CI machines with low resources.
 GO_LINT_ARGS := --timeout 10m0s --out-format=checkstyle > $(GO_LINT_OUTPUT)/checkstyle.xml
-
-# Output verbose tests that can be parsed into JUnit XML.
-GO_TEST_FLAGS += -v
 endif
 
 # NOTE: the install suffixes are matched with the build container to speed up the

--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -65,7 +65,7 @@ $(HELM_OUTPUT_DIR):
 define helm.chart
 $(HELM_OUTPUT_DIR)/$(1)-$(HELM_CHART_VERSION).tgz: $(HELM_HOME) $(HELM_OUTPUT_DIR) $(shell find $(HELM_CHARTS_DIR)/$(1) -type f)
 	@$(INFO) helm package $(1) $(HELM_CHART_VERSION)
-	@$(HELM) package --version $(HELM_CHART_VERSION) --app-version $(HELM_CHART_VERSION) -d $(HELM_OUTPUT_DIR) $(abspath $(HELM_CHARTS_DIR)/$(1))
+	@$(HELM) package --version $(HELM_CHART_VERSION) --app-version $(HELM_CHART_VERSION) --save=false -d $(HELM_OUTPUT_DIR) $(abspath $(HELM_CHARTS_DIR)/$(1))
 	@$(OK) helm package $(1) $(HELM_CHART_VERSION)
 
 helm.prepare.$(1): $(HELM_HOME)


### PR DESCRIPTION
Expected to fix following sporadic build failure for repos with more than one helm charts (e.g. wesaas):

```
20:17:17 [ OK ] helm package maincluster-operator 0.14.0-alpha1.25.gdde3e70
20:17:17 [ .. ] helm package crossplane-cluster-velero 0.14.0-alpha1.25.gdde3e70
Successfully packaged chart and saved it to: /home/upbound/go/src/github.com/upbound/wesaas/_output/charts/hostcluster-base-0.14.0-alpha1.25.gdde3e70.tgz
Successfully packaged chart and saved it to: /home/upbound/go/src/github.com/upbound/wesaas/_output/charts/hostcluster-tiers-gcp-0.14.0-alpha1.25.gdde3e70.tgz
Successfully packaged chart and saved it to: /home/upbound/go/src/github.com/upbound/wesaas/_output/charts/hostcluster-tiers-localdev-0.14.0-alpha1.25.gdde3e70.tgz
WARNING: Deprecated index file format. Try 'helm repo update'
Error: no API version specified
build/makelib/helm.mk:92: recipe for target '/home/upbound/go/src/github.com/upbound/wesaas/_output/charts/hostcluster-tiers-localdev-0.14.0-alpha1.25.gdde3e70.tgz' failed
make[1]: *** [/home/upbound/go/src/github.com/upbound/wesaas/_output/charts/hostcluster-tiers-localdev-0.14.0-alpha1.25.gdde3e70.tgz] Error 1
make[1]: *** Waiting for unfinished jobs....
20:17:17 [ OK ] helm package hostcluster-base 0.14.0-alpha1.25.gdde3e70
20:17:17 [ OK ] helm package hostcluster-tiers-gcp 0.14.0-alpha1.25.gdde3e70
Successfully packaged chart and saved it to: /home/upbound/go/src/github.com/upbound/wesaas/_output/charts/crossplane-cluster-velero-0.14.0-alpha1.25.gdde3e70.tgz
20:17:17 [ OK ] helm package crossplane-cluster-velero 0.14.0-alpha1.25.gdde3e70
build/makelib/common.mk:302: recipe for target 'build.all' failed
make: *** [build.all] Error 2
 
Exited with code exit status 1 
```

---
`helm package` saves chart to local chart repo by default. When
we have multiple charts in a repo and make is called with -j n,
parallel runs of helm package sporadically cause a race condition
while updating index.yaml file for local repo. We don't need this
functionality at all as we are already storing charts to our
output_dir and index later with a helm index target.

Signed-off-by: Hasan Turken <turkenh@gmail.com>