### PR TITLE
Add Local Development Targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ make -j tests
 
 To see the help run `make help`.
 
+## Local Development Setup
+
+To use local development targets, first include `deploy.mk` in your make file:
+
+```
+include build/makelib/local.mk
+```
+
+Then, run the following command to initialize a local development configuration:
+
+```
+make local.scaffold
+```
+
+You can now configure and add more components (i.e. helm releases) to your local development setup.
+
 ## Contributing
 
 We welcome contributions. See [Contributing](CONTRIBUTING.md) to get started.

--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -40,7 +40,7 @@ HELM_HOME := $(abspath $(WORK_DIR)/helm)
 export HELM_HOME
 
 # helm tool version
-HELM_VERSION ?= v2.15.1
+HELM_VERSION ?= v2.16.7
 HELM := $(TOOLS_HOST_DIR)/helm-$(HELM_VERSION)
 
 # remove the leading `v` for helm chart versions

--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -43,6 +43,7 @@ build.vars: k8s_tools.buildvars
 # kind download and install
 $(KIND):
 	@$(INFO) installing kind $(KIND_VERSION)
+	@mkdir -p $(TOOLS_HOST_DIR) || $(FAIL)
 	@curl -fsSLo $(KIND) https://github.com/kubernetes-sigs/kind/releases/download/$(KIND_VERSION)/kind-$(GOHOSTOS)-$(GOHOSTARCH) || $(FAIL)
 	@chmod +x $(KIND) 
 	@$(OK) installing kind $(KIND_VERSION)

--- a/makelib/local.mk
+++ b/makelib/local.mk
@@ -1,0 +1,132 @@
+SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+SCRIPTS_DIR := $(SELF_DIR)/../scripts
+
+KIND_CLUSTER_NAME ?= local-dev
+DEPLOY_LOCAL_DIR ?= $(ROOT_DIR)/cluster/local/localdev
+DEPLOY_LOCAL_CONFIG_DIR := $(DEPLOY_LOCAL_DIR)/config
+DEPLOY_LOCAL_KUBECONFIG := $(DEPLOY_LOCAL_DIR)/kubeconfig
+KIND_CONFIG_FILE := $(DEPLOY_LOCAL_DIR)/kind.yaml
+KUBECONFIG ?= $(HOME)/.kube/config
+
+LOCAL_BUILD ?= "true"
+
+export KIND
+export KUBECTL
+export HELM
+export GOMPLATE
+export BUILD_REGISTRY
+export ROOT_DIR
+export SCRIPTS_DIR
+export KIND_CLUSTER_NAME
+export DEPLOY_LOCAL_DIR
+export DEPLOY_LOCAL_CONFIG_DIR
+export DEPLOY_LOCAL_KUBECONFIG
+export KIND_CONFIG_FILE
+export KUBECONFIG
+export LOCAL_BUILD
+export HELM_OUTPUT_DIR
+export BUILD_HELM_CHART_VERSION=$(HELM_CHART_VERSION)
+export BUILD_HELM_CHARTS_LIST=$(HELM_CHARTS)
+export BUILD_REGISTRIES=$(REGISTRIES)
+export BUILD_IMAGES=$(IMAGES)
+export BUILD_IMAGE_ARCHS=$(subst linux_,,$(filter linux_%,$(BUILD_PLATFORMS)))
+
+# Install gomplate
+GOMPLATE_VERSION := 3.7.0
+GOMPLATE := $(TOOLS_HOST_DIR)/gomplate-$(GOMPLATE_VERSION)
+
+gomplate.buildvars:
+	@echo GOMPLATE=$(GOMPLATE)
+
+build.vars: gomplate.buildvars
+
+$(GOMPLATE):
+	@$(INFO) installing gomplate $(HOSTOS)-$(HOSTARCH)
+	@curl -fsSLo $(GOMPLATE) https://github.com/hairyhenderson/gomplate/releases/download/v$(GOMPLATE_VERSION)/gomplate_$(HOSTOS)-$(HOSTARCH) || $(FAIL)
+	@chmod +x $(GOMPLATE)
+	@$(OK) installing gomplate $(HOSTOS)-$(HOSTARCH)
+
+kind.up: $(KIND)
+	@$(INFO) kind up
+	@$(KIND) get kubeconfig --name $(KIND_CLUSTER_NAME) >/dev/null 2>&1 || $(KIND) create cluster --name=$(KIND_CLUSTER_NAME) --config="$(KIND_CONFIG_FILE)" --kubeconfig="$(KUBECONFIG)"
+	@$(KIND) get kubeconfig --name $(KIND_CLUSTER_NAME) > $(DEPLOY_LOCAL_KUBECONFIG)
+	@$(OK) kind up
+
+kind.down: $(KIND)
+	@$(INFO) kind down
+	@$(KIND) delete cluster --name=$(KIND_CLUSTER_NAME)
+	@$(OK) kind down
+
+kind.setcontext: $(KUBECTL)
+	@$(KUBECTL) --kubeconfig $(KUBECONFIG) config use-context kind-$(KIND_CLUSTER_NAME)
+
+kind.buildvars:
+	@echo DEPLOY_LOCAL_KUBECONFIG=$(DEPLOY_LOCAL_KUBECONFIG)
+
+build.vars: kind.buildvars
+clean: kind.down
+
+.PHONY: kind.up kind.down kind.setcontext kind.buildvars
+
+local.helminit: $(KUBECTL) $(HELM) kind.setcontext
+	@$(INFO) helm init
+	@docker pull gcr.io/kubernetes-helm/tiller:$(HELM_VERSION)
+	@$(KIND) load docker-image gcr.io/kubernetes-helm/tiller:$(HELM_VERSION) --name=$(KIND_CLUSTER_NAME)
+	@$(KUBECTL) --kubeconfig $(KUBECONFIG) --namespace kube-system get serviceaccount tiller > /dev/null 2>&1 || $(KUBECTL) --kubeconfig $(KUBECONFIG) --namespace kube-system create serviceaccount tiller
+	@$(KUBECTL) --kubeconfig $(KUBECONFIG) get clusterrolebinding tiller-cluster-rule > /dev/null 2>&1 || $(KUBECTL) --kubeconfig $(KUBECONFIG) create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+	@$(HELM) ls > /dev/null 2>&1 || $(HELM) init --kubeconfig $(KUBECONFIG) --service-account tiller --upgrade --wait
+	@$(HELM) repo update
+	@$(OK) helm init
+
+local.up: kind.up local.helminit
+
+local.down: kind.down
+
+local.deploy.%: $(KUBECTL) $(HELM) $(HELM_HOME) $(GOMPLATE) kind.setcontext
+	@$(INFO) localdev deploy component: $*
+	@$(eval PLATFORMS=$(BUILD_PLATFORMS))
+	@$(SCRIPTS_DIR)/localdev-deploy-component.sh $* || $(FAIL)
+	@$(OK) localdev deploy component: $*
+
+local.remove.%: $(KUBECTL) $(HELM) $(HELM_HOME) $(GOMPLATE) kind.setcontext
+	@$(INFO) localdev remove component: $*
+	@$(SCRIPTS_DIR)/localdev-remove-component.sh $* || $(FAIL)
+	@$(OK) localdev remove component: $*
+
+local.scaffold:
+	@$(INFO) localdev scaffold config
+	@$(SCRIPTS_DIR)/localdev-scaffold.sh || $(FAIL)
+	@$(OK) localdev scaffold config
+
+.PHONY: local.helminit local.up local.deploy.% local.remove.%  local.scaffold
+
+# ====================================================================================
+# Special Targets
+
+fmt: go.imports
+fmt.simplify: go.fmt.simplify
+imports: go.imports
+imports.fix: go.imports.fix
+vendor: go.vendor
+vendor.check: go.vendor.check
+vendor.update: go.vendor.update
+vet: go.vet
+generate codegen: go.generate
+
+define LOCAL_HELPTEXT
+Local Targets:
+    local.scaffold	scaffold a local development configuration
+    local.up		stand up of a local development cluster with kind
+    local.down		tear down local development cluster
+    local.deploy.%	install/upgrade a local/external component, for example, local.deploy.crossplane
+    local.remove.%	removes component, for example, local.remove.crossplane
+
+endef
+export LOCAL_HELPTEXT
+
+local.help:
+	@echo "$$LOCAL_HELPTEXT"
+
+help-special: local.help
+
+###

--- a/scripts/load-configs.sh
+++ b/scripts/load-configs.sh
@@ -24,12 +24,19 @@ HELM_REPOSITORY_FORCE_UPDATE="false"
 HELM_RELEASE_NAME=""
 # HELM_RELEASE_NAMESPACE is the namespace for the helm release.
 HELM_RELEASE_NAMESPACE="default"
+# HELM_DELETE_ON_FAILURE controls whether to delete/rollback a failed install/upgrade.
+HELM_DELETE_ON_FAILURE="true"
 
 # COMPONENT_SKIP_DEPLOY controls whether (conditionally) skip deployment of a component or not.
 COMPONENT_SKIP_DEPLOY="false"
 
 MAIN_CONFIG_FILE="${DEPLOY_LOCAL_CONFIG_DIR}/config.env"
-COMPONENT_CONFIG_FILE="${DEPLOY_LOCAL_CONFIG_DIR}/${COMPONENT}/config.env"
+COMPONENT_CONFIG_DIR="${DEPLOY_LOCAL_CONFIG_DIR}/${COMPONENT}"
+COMPONENT_CONFIG_FILE="${COMPONENT_CONFIG_DIR}/config.env"
+
+if [[ ! -d "${COMPONENT_CONFIG_DIR}" ]]; then
+  echo_error "Component config dir \"${COMPONENT_CONFIG_DIR}\" does not exist (or is not a directory), did you run make local.prepare ?"
+fi
 
 if [[ -f "${MAIN_CONFIG_FILE}" ]]; then
   source "${MAIN_CONFIG_FILE}"

--- a/scripts/load-configs.sh
+++ b/scripts/load-configs.sh
@@ -1,0 +1,39 @@
+COMPONENT=$1
+
+# REQUIRED_IMAGES is the array of images that the COMPONENT needs.
+# These images will be pulled (if not exists) and loaded into the kind cluster before deployment.
+# If an image has tags, it will be used.
+# If an image does not have a tag, "v${HELM_CHART_VERSION}" will be used as a tag.
+REQUIRED_IMAGES=()
+
+# HELM_CHART_NAME is the name of the helm chart to deploy. If not set, defaults to COMPONENT
+HELM_CHART_NAME=""
+# HELM_CHART_VERSION is the version of the helm chart to deploy.
+# If LOCAL_BUILD=true, HELM_CHART_VERSION will be set the version in build system.
+# If LOCAL_BUILD=false, HELM_CHART_VERSION defaults to latest version in the HELM_REPOSITORY
+HELM_CHART_VERSION=""
+# HELM_REPOSITORY_NAME is the name of the helm repository.
+# This will only be used if LOCAL_BUILD=false or HELM_CHART_NAME is not a local chart (e.g. not in HELM_CHARTS array)
+HELM_REPOSITORY_NAME=""
+# HELM_REPOSITORY_NAME is the url of the helm repository.
+HELM_REPOSITORY_URL=""
+# HELM_REPOSITORY_FORCE_UPDATE controls whether always update helm repositories or not.
+# If false, "helm repo update" will only be called if repo does not exist already.
+HELM_REPOSITORY_FORCE_UPDATE="false"
+# HELM_RELEASE_NAME is the name of the helm release. If not set, defaults to COMPONENT
+HELM_RELEASE_NAME=""
+# HELM_RELEASE_NAMESPACE is the namespace for the helm release.
+HELM_RELEASE_NAMESPACE="default"
+
+# COMPONENT_SKIP_DEPLOY controls whether (conditionally) skip deployment of a component or not.
+COMPONENT_SKIP_DEPLOY="false"
+
+MAIN_CONFIG_FILE="${DEPLOY_LOCAL_CONFIG_DIR}/config.env"
+COMPONENT_CONFIG_FILE="${DEPLOY_LOCAL_CONFIG_DIR}/${COMPONENT}/config.env"
+
+if [[ -f "${MAIN_CONFIG_FILE}" ]]; then
+  source "${MAIN_CONFIG_FILE}"
+fi
+if [[ -f "${COMPONENT_CONFIG_FILE}" ]]; then
+  source "${COMPONENT_CONFIG_FILE}"
+fi

--- a/scripts/localdev-deploy-component.sh
+++ b/scripts/localdev-deploy-component.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -aeuo pipefail
+
+COMPONENT=$1
+
+# Source utility functions
+source "${SCRIPTS_DIR}/utils.sh"
+# sourcing load-configs.sh:
+#   - initializes configuration variables with default values
+#   - loads top level configuration
+#   - loads component level configuration
+source "${SCRIPTS_DIR}/load-configs.sh" "${COMPONENT}"
+
+# Skip deployment of this component if COMPONENT_SKIP_DEPLOY is set to true
+if [ "${COMPONENT_SKIP_DEPLOY}" == "true" ]; then
+  echo "COMPONENT_SKIP_DEPLOY set to true, skipping deployment of ${COMPONENT}"
+  exit 0
+fi
+
+# if HELM_CHART_NAME is not set, default to component name
+if [ -z "${HELM_CHART_NAME}" ]; then
+  HELM_CHART_NAME="${COMPONENT}"
+fi
+
+registries_arr=($BUILD_REGISTRIES)
+images_arr=($BUILD_IMAGES)
+image_archs_arr=($BUILD_IMAGE_ARCHS)
+charts_arr=($BUILD_HELM_CHARTS_LIST)
+
+if [ "${LOCAL_BUILD}" == "true" ] && containsElement "${HELM_CHART_NAME}" "${charts_arr[@]}"; then
+  # If local build is set and helm chart is from this repository, use locally build helm chart tgz file.
+  echo "Deploying locally built artifacts..."
+  HELM_CHART_VERSION=${BUILD_HELM_CHART_VERSION}
+  HELM_CHART_REF="${HELM_OUTPUT_DIR}/${COMPONENT}-${HELM_CHART_VERSION}.tgz"
+  [ -f "${HELM_CHART_REF}" ] || echo_error "Local chart ${HELM_CHART_REF} not found. Did you run \"make build\" ? "
+
+  # If local build, tag "required" local images, so that they can be load into kind cluster at a later step.
+  for r in "${registries_arr[@]}"; do
+    for i in "${images_arr[@]}"; do
+      for a in "${image_archs_arr[@]}"; do
+        if containsElement "${r}/${i}" "${REQUIRED_IMAGES[@]}"; then
+          echo "Tagging locally built image as ${r}/${i}:${VERSION}"
+          docker tag "${BUILD_REGISTRY}/${i}-${a}" "${r}/${i}:${VERSION}"
+        fi
+      done
+    done
+  done
+else
+  # If local build is NOT set or helm chart is NOT from this repository, deploy chart from a remote repository.
+  echo "Deploying latest artifacts in chart repo \"${HELM_REPOSITORY_NAME}\"..."
+  HELM_CHART_REF="${HELM_REPOSITORY_NAME}/${HELM_CHART_NAME}"
+  # Add helm repo and update repositories, if repo is not added already or force update is set.
+  if [ "${HELM_REPOSITORY_FORCE_UPDATE}" == "true" ] || ! "${HELM}" repo list -o yaml |grep "Name:\s*${HELM_REPOSITORY_NAME}\s*$" >/dev/null; then
+    "${HELM}" repo add "${HELM_REPOSITORY_NAME}" "${HELM_REPOSITORY_URL}"
+    "${HELM}" repo update
+  fi
+  if [ -z "${HELM_CHART_VERSION}" ]; then
+    # if no HELM_CHART_VERSION provided, then get the latest version from repo which will be used to load required images for chart.
+    HELM_CHART_VERSION=$("${HELM}" search -l ${HELM_CHART_REF} --devel |awk 'NR==2{print $2}')
+  fi
+fi
+
+# shellcheck disable=SC2068
+for i in ${REQUIRED_IMAGES[@]+"${REQUIRED_IMAGES[@]}"}; do
+  # check if image has a tag, if not, append tag for the chart
+  if ! echo "${i}" | grep ":"; then
+    i="${i}:v${HELM_CHART_VERSION}"
+  fi
+  # Pull the image:
+  # - if has a tag "master" or "latest"
+  # - or does not exist already.
+  if echo "${i}" | grep ":master\s*$" >/dev/null || echo "${i}" | grep ":latest\s*$" >/dev/null || ! docker inspect --type=image "${i}" >/dev/null 2>&1; then
+    docker pull "${i}"
+  fi
+  "${KIND}" load docker-image "${i}" --name="${KIND_CLUSTER_NAME}"
+done
+
+
+PREDEPLOY_SCRIPT="${DEPLOY_LOCAL_CONFIG_DIR}/${COMPONENT}/pre-deploy.sh"
+POSTDEPLOY_SCRIPT="${DEPLOY_LOCAL_CONFIG_DIR}/${COMPONENT}/post-deploy.sh"
+
+# Run config.validate.sh if exists.
+test -f "${DEPLOY_LOCAL_CONFIG_DIR}/config.validate.sh" && source "${DEPLOY_LOCAL_CONFIG_DIR}/config.validate.sh"
+
+helm_chart_version_flag="--devel"
+
+# Create the HELM_RELEASE_NAMESPACE if not exist already.
+"${KUBECTL}" --kubeconfig "${KUBECONFIG}" get ns "${HELM_RELEASE_NAMESPACE}" >/dev/null 2>&1 || ${KUBECTL} \
+  --kubeconfig "${KUBECONFIG}" create ns "${HELM_RELEASE_NAMESPACE}"
+
+# Run pre-deploy script, if exists.
+if [ -f "${PREDEPLOY_SCRIPT}" ]; then
+  source "${PREDEPLOY_SCRIPT}"
+fi
+
+# With all configuration sourced as environment variables, render value-overrides.yaml file with gomplate.
+"${GOMPLATE}" -f "${DEPLOY_LOCAL_CONFIG_DIR}/${COMPONENT}/value-overrides.yaml.tmpl" \
+  -o "${DEPLOY_LOCAL_CONFIG_DIR}/${COMPONENT}/value-overrides.yaml"
+
+if [ -n "${HELM_CHART_VERSION}" ]; then
+  helm_chart_version_flag="--version ${HELM_CHART_VERSION}"
+fi
+
+# if HELM_RELEASE_NAME is not set, default to component name
+if [ -z "${HELM_RELEASE_NAME}" ]; then
+  HELM_RELEASE_NAME=${COMPONENT}
+fi
+
+# Run helm upgrade --install with computed parameters.
+# shellcheck disable=SC2086
+"${HELM}" upgrade --install "${HELM_RELEASE_NAME}" --namespace "${HELM_RELEASE_NAMESPACE}" --kubeconfig "${KUBECONFIG}" \
+  "${HELM_CHART_REF}" ${helm_chart_version_flag:-} -f "${DEPLOY_LOCAL_CONFIG_DIR}/${COMPONENT}/value-overrides.yaml" \
+  --atomic --force
+
+# Run post-deploy script, if exists.
+if [ -f "${POSTDEPLOY_SCRIPT}" ]; then
+  source "${POSTDEPLOY_SCRIPT}"
+fi

--- a/scripts/localdev-prepare.sh
+++ b/scripts/localdev-prepare.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -aeuo pipefail
+
+# Source utility functions
+source "${SCRIPTS_DIR}/utils.sh"
+
+# prepare local dev configuration under ".work/local" by gathering configuration from different repositories.
+LOCALDEV_WORKDIR=${WORK_DIR}/local
+
+mkdir -p "${LOCALDEV_WORKDIR}"
+
+if [ -n "${LOCALDEV_INTEGRATION_CONFIG_REPO}" ]; then
+  # if a local dev integration config repo configured
+
+  echo "Using integration config from repo ${LOCALDEV_INTEGRATION_CONFIG_REPO}"
+  # shallow clone integration config repo, only clone if not already.
+  test -d "${DEPLOY_LOCAL_WORKDIR}" || git clone --depth 1 "${LOCALDEV_INTEGRATION_CONFIG_REPO}" "${DEPLOY_LOCAL_WORKDIR}"
+
+  LOCALDEV_WORKDIR_REPOS=${LOCALDEV_WORKDIR}/repos
+
+  # source repo list
+  source ${DEPLOY_LOCAL_WORKDIR}/repos.env
+
+  echo "${DEPLOY_LOCAL_REPOS[@]}"
+  for i in "${DEPLOY_LOCAL_REPOS[@]}"; do
+
+    local_repo=$(basename $(git config --get remote.origin.url) .git)
+    repo=$(basename "${i}" .git)
+
+    if [ "${LOCAL_BUILD}" == "true" ] && [ "${repo}" == "${local_repo}" ]; then
+      # if it is a local build and repo is the local one, just use local config
+
+      echo "Using local config for repo ${repo}"
+      repo_dir="${ROOT_DIR}"
+    else
+      # otherwise, shallow clone the repo
+
+      echo "Cloning repo ${repo} to get local dev config"
+      repo_dir=${LOCALDEV_WORKDIR_REPOS}/${repo}
+
+      # only clone if not cloned already.
+      test -d "${repo_dir}" || git clone --depth 1 ${i} "${repo_dir}"
+    fi
+
+    # copy local dev config under workdir
+    # TODO(hasan): `cluster/local/config` should not be hardcoded, should be part of repo configuration somehow (repos.env)
+    if [ -d ${repo_dir}/cluster/local/config ]; then
+      cp -rf "${repo_dir}/cluster/local/config/." "${DEPLOY_LOCAL_WORKDIR}/config"
+    else
+      echo_warn "No local dev config found for repo ${repo}!"
+    fi
+  done
+else
+  # if no local dev integration config repo configured, e.g. localdev only using this repo.
+
+  echo "No integration config repo configured, using local config"
+  cp -rf "${DEPLOY_LOCAL_DIR}/." "${DEPLOY_LOCAL_WORKDIR}"
+fi

--- a/scripts/localdev-remove-component.sh
+++ b/scripts/localdev-remove-component.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -aeuo pipefail
+
+COMPONENT=$1
+
+source "${SCRIPTS_DIR}/utils.sh"
+source "${SCRIPTS_DIR}/load-configs.sh" "${COMPONENT}"
+
+if [ -z "${HELM_RELEASE_NAME}" ]; then
+  HELM_RELEASE_NAME=${COMPONENT}
+fi
+
+"${HELM}" delete "${HELM_RELEASE_NAME}" --kubeconfig "${KUBECONFIG}" --purge

--- a/scripts/localdev-scaffold.sh
+++ b/scripts/localdev-scaffold.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -aeuo pipefail
+
+deploy_local_root=${ROOT_DIR}/cluster/local
+
+read -p "Enter a name for local development configuration [localdev]: " config_name
+config_name=${config_name:-localdev}
+
+local_config_root=${deploy_local_root}/${config_name}
+test -d ${local_config_root} && { echo "Directory \"${local_config_root}\" already exists. Please select a different name!"; exit 1; }
+
+charts_arr=($BUILD_HELM_CHARTS_LIST)
+default_component="${charts_arr[0]}"
+read -p "Enter a name for component to deploy [${default_component}]: " component
+component=${component:-"${default_component}"}
+
+local_config_dir=${local_config_root}/config
+
+echo "creating directory ${local_config_root}"
+mkdir -p "${local_config_root}"
+echo "creating directory ${local_config_dir}/${component}"
+mkdir -p "${local_config_dir}/${component}"
+
+echo "initiazing file ${local_config_root}/kind.yaml"
+cat << EOF > ${local_config_root}/kind.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+EOF
+
+echo "initiazing file ${local_config_dir}/config.env"
+cat << EOF > ${local_config_dir}/config.env
+IMAGE_CROSSPLANE="crossplane/crossplane"
+
+echo "replace this with top level config"
+PARAM_FROM_TOP_LEVEL_CONFIG="top-level-config"
+EOF
+
+echo "initiazing file ${local_config_dir}/config.validate.sh"
+cat << EOF > ${local_config_dir}/config.validate.sh
+echo "replace this with top level config validation script"
+EOF
+
+echo "initiazing file ${local_config_dir}/${component}/config.env"
+cat << EOF > ${local_config_dir}/${component}/config.env
+REQUIRED_IMAGES+=("\${IMAGE_CROSSPLANE}")
+
+#HELM_CHART_NAME=""
+#HELM_CHART_VERSION=""
+#HELM_REPOSITORY_NAME=""
+#HELM_REPOSITORY_URL=""
+#HELM_REPOSITORY_FORCE_UPDATE="false"
+#HELM_RELEASE_NAME=""
+#HELM_RELEASE_NAMESPACE="default"
+
+echo "replace this with component config"
+PARAM_FROM_COMPONENT_CONFIG="component-config"
+EOF
+
+echo "initiazing file ${local_config_dir}/${component}/pre-deploy.sh"
+cat << EOF > ${local_config_dir}/${component}/pre-install.sh
+# remove this file if the component does not need pre-deploy steps.
+echo "running pre-deploy script..."
+EOF
+
+echo "initiazing file ${local_config_dir}/${component}/post-deploy.sh"
+cat << EOF > ${local_config_dir}/${component}/post-install.sh
+# remove this file if the component does not need post-deploy steps.
+echo "running post-deploy script..."
+EOF
+
+echo "initiazing file ${local_config_dir}/${component}/.gitignore"
+cat << EOF > ${local_config_dir}/${component}/.gitignore
+value-overrides.yaml
+EOF
+
+echo "initiazing file ${local_config_dir}/${component}/value-overrides.yaml.tmpl"
+cat << EOF > ${local_config_dir}/${component}/value-overrides.yaml.tmpl
+image:
+  pullPolicy: Never
+
+paramFromTopLevel: {{ .Env.PARAM_FROM_TOP_LEVEL_CONFIG }}
+paramFromComponent: {{ .Env.PARAM_FROM_COMPONENT_CONFIG }}
+EOF
+
+echo "done!"
+
+echo """
+Run the following command to deploy locally built component (or consider adding as a target to makefile):
+  DEPLOY_LOCAL_DIR=${local_config_root} LOCAL_BUILD=true make local.up local.deploy.${component}
+"""

--- a/scripts/localdev-scaffold.sh
+++ b/scripts/localdev-scaffold.sh
@@ -3,11 +3,8 @@ set -aeuo pipefail
 
 deploy_local_root=${ROOT_DIR}/cluster/local
 
-read -p "Enter a name for local development configuration [localdev]: " config_name
-config_name=${config_name:-localdev}
-
-local_config_root=${deploy_local_root}/${config_name}
-test -d ${local_config_root} && { echo "Directory \"${local_config_root}\" already exists. Please select a different name!"; exit 1; }
+local_config_root=${deploy_local_root}
+test -d ${local_config_root}/config && { echo "Directory \"${local_config_root}/config\" already exists!"; exit 1; }
 
 charts_arr=($BUILD_HELM_CHARTS_LIST)
 default_component="${charts_arr[0]}"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,30 @@
+################################# setup colors
+# setting up colors
+BLU='\033[0;34m'
+YLW='\033[0;33m'
+GRN='\033[0;32m'
+RED='\033[0;31m'
+NOC='\033[0m' # No Color
+
+echo_info(){
+    printf "\n${BLU}%s${NOC}" "$1"
+}
+
+echo_success(){
+    printf "\n${GRN}%s${NOC}\n" "$1"
+}
+echo_warn(){
+    printf "\n${YLW}%s${NOC}\n" "$1"
+}
+echo_error(){
+    printf "\n${RED}%s${NOC}\n" "$1"
+    return 1
+}
+#################################
+
+containsElement () {
+  local e match="$1"
+  shift
+  for e; do [[ "$e" == "$match" ]] && return 0; done
+  return 1
+}


### PR DESCRIPTION
Introducing local development targets:

New build commands and related config:
  - `kind.up`: stands up a kind cluster and add context to the kubeconfig
    - `KIND_CLUSTER_NAME ?= local-dev`
    - `KIND_CONFIG_FILE` - Ability to set different version or any config for kind
    - `KUBECONFIG ?= $(HOME)/.kube/config`
  - `kind.down`: deletes kind cluster
  - `kind.setcontext`: sets kubeconfig context to use config of the kind cluster.
  - `local.helminit`: initializes helm2 with pre-pulled/loaded tiller image and proper cluster roles, updates helm repos.
  - `local.up`: `kind.up` + `local.helminit`
  - `local.down`: `kind.down` + any necessary cleanup
  - `local.deploy.%`: installs/upgrades a local/external component (e.g. helm chart)
  - `local.remove.%`: removes component
  - `local.scaffold`: scaffold initial local development configuration

All `local.` targets ensure they are running inside the kind cluster (i.e. depends `kind.setcontext`) to prevent mistakes.
