### PR TITLE
Don't clean local with local down

### DIFF
--- a/makelib/local.mk
+++ b/makelib/local.mk
@@ -95,7 +95,7 @@ local.clean:
 
 local.up: local.prepare kind.up local.helminit
 
-local.down: local.clean kind.down
+local.down: kind.down
 
 local.deploy.%: $(KUBECTL) $(HELM) $(HELM_HOME) $(GOMPLATE) kind.setcontext
 	@$(INFO) localdev deploy component: $*


### PR DESCRIPTION
`make clean` already delete whole `.work` directory. Trying to delete `.work/local` with `make clean` causes sporadic errors.

Signed-off-by: Hasan Turken <turkenh@gmail.com>