### PR TITLE
Adding kind.up prereq to kind.setcontext target

### DIFF
--- a/makelib/local.mk
+++ b/makelib/local.mk
@@ -65,7 +65,7 @@ kind.down: $(KIND)
 	@$(KIND) delete cluster --name=$(KIND_CLUSTER_NAME)
 	@$(OK) kind down
 
-kind.setcontext: $(KUBECTL)
+kind.setcontext: $(KUBECTL) kind.up
 	@$(KUBECTL) --kubeconfig $(KUBECONFIG) config use-context kind-$(KIND_CLUSTER_NAME)
 
 kind.buildvars:


### PR DESCRIPTION
- kind.up needs to run first so that the kind kubeconfig context exists