### PR TITLE
Fix undefined HELM_HOME if makelib/helm not included

### DIFF
--- a/makelib/local.mk
+++ b/makelib/local.mk
@@ -13,6 +13,14 @@ LOCALDEV_CLONE_WITH ?= ssh # or https
 LOCALDEV_LOCAL_BUILD ?= true
 LOCALDEV_PULL_LATEST ?= true
 
+ifeq ($(HELM_HOME),)
+HELM_HOME := $(abspath $(WORK_DIR)/helm)
+export HELM_HOME
+$(HELM_HOME): $(HELM)
+	@mkdir -p $(HELM_HOME)
+	@$(HELM) init -c
+endif
+
 export KIND
 export KUBECTL
 export HELM


### PR DESCRIPTION
HELM_HOME is defined in `makelib/helm.mk`, however, it is not possible to include `makelib/helm.mk` if repo has no helm charts where it fails with `the variable HELM_CHARTS must be set prior to including helm.mk`.

We want to still use local dev tooling even the repo has no helm charts (e.g. deploying existing charts from other repositories).

Signed-off-by: Hasan Turken <turkenh@gmail.com>