### PR TITLE
Bump golangci-lint version

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -96,7 +96,7 @@ endif
 
 # We use a consistent version of golangci-lint to ensure everyone gets the same
 # linters.
-GOLANGCILINT_VERSION ?= 1.23.8
+GOLANGCILINT_VERSION ?= 1.31.0
 GOLANGCILINT := $(TOOLS_HOST_DIR)/golangci-lint-v$(GOLANGCILINT_VERSION)
 
 GO_BIN_DIR := $(abspath $(OUTPUT_DIR)/bin)


### PR DESCRIPTION
I'd like to update our linting Github action(s), and the actions don't support this fairly old version of golangci-lint. I've tested the new version against crossplane, crossplane-runtime, and provider-gcp. It introduces some new lint rules that will need to be addressed, but otherwise works fine.