### PR TITLE
Update readme: include k8s_tools for helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ HELM_BASE_URL = https://charts.upbound.io
 HELM_S3_BUCKET = upbound.charts
 HELM_CHARTS = myrepo-api
 HELM_CHART_LINT_ARGS_myrepo-api = --set nameOverride='',imagePullSecrets=''
+include build/makelib/k8s_tools.mk
 include build/makelib/helm.mk
 
 # Docker images


### PR DESCRIPTION
With #106 helm target moved to a separate .mk file, for re-usability, breaking current setup in Readme which is fixed with this commit.