### PR TITLE
Fixes for helm3

### DIFF
--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -39,6 +39,16 @@ HELM_INDEX := $(HELM_OUTPUT_DIR)/index.yaml
 HELM_HOME := $(abspath $(WORK_DIR)/helm)
 export HELM_HOME
 
+# https://helm.sh/docs/faq/#xdg-base-directory-support
+ifeq ($(USE_HELM3),true)
+XDG_DATA_HOME := $(HELM_HOME)
+XDG_CONFIG_HOME := $(HELM_HOME)
+XDG_CACHE_HOME := $(HELM_HOME)
+export XDG_DATA_HOME
+export XDG_CONFIG_HOME
+export XDG_CACHE_HOME
+endif
+
 # remove the leading `v` for helm chart versions
 HELM_CHART_VERSION := $(VERSION:v%=%)
 

--- a/makelib/local.mk
+++ b/makelib/local.mk
@@ -25,6 +25,7 @@ export KIND
 export KUBECTL
 export HELM
 export HELM3
+export USE_HELM3
 export GOMPLATE
 export ISTIO
 export ISTIO_VERSION
@@ -109,7 +110,11 @@ local.clean:
 	@rm -rf $(WORK_DIR)/local || $(FAIL)
 	@$(OK) cleaning local dev workdir
 
+ifeq ($(USE_HELM3),true)
+local.up: local.prepare kind.up
+else
 local.up: local.prepare kind.up local.helminit
+endif
 
 local.down: kind.down local.clean
 

--- a/scripts/load-configs.sh
+++ b/scripts/load-configs.sh
@@ -30,8 +30,6 @@ HELM_DELETE_ON_FAILURE="true"
 # COMPONENT_SKIP_DEPLOY controls whether (conditionally) skip deployment of a component or not.
 COMPONENT_SKIP_DEPLOY="false"
 
-USE_HELM3="false"
-
 MAIN_CONFIG_FILE="${DEPLOY_LOCAL_CONFIG_DIR}/config.env"
 COMPONENT_CONFIG_DIR="${DEPLOY_LOCAL_CONFIG_DIR}/${COMPONENT}"
 COMPONENT_CONFIG_FILE="${COMPONENT_CONFIG_DIR}/config.env"

--- a/scripts/localdev-deploy-component.sh
+++ b/scripts/localdev-deploy-component.sh
@@ -3,6 +3,14 @@ set -aeuo pipefail
 
 COMPONENT=$1
 
+# Commands for searching a repo differs for helm2 and helm3
+# helm2 search -l <ref>
+# helm3 search repo -l <ref>
+HELM_SEARCH_REPO="${HELM} search"
+if [ "${USE_HELM3}" == "true" ]; then
+  HELM_SEARCH_REPO="${HELM} search repo"
+fi
+
 # Source utility functions
 source "${SCRIPTS_DIR}/utils.sh"
 # sourcing load-configs.sh:
@@ -34,18 +42,6 @@ if [ -f "${DEPLOY_SCRIPT}" ]; then
   source "${DEPLOY_SCRIPT}"
   echo_info "Running deploy script...OK"
   exit 0
-fi
-
-# Commands for searching a repo differs for helm2 and helm3
-# helm2 search -l <ref>
-# helm3 search repo -l <ref>
-HELM_SEARCH_REPO="${HELM} search"
-if [ "${USE_HELM3}" == "true" ]; then
-  HELM="${HELM3}"
-  HELM_SEARCH_REPO="${HELM3} search repo"
-  XDG_DATA_HOME="${HELM_HOME}"
-  XDG_CONFIG_HOME="${HELM_HOME}"
-  XDG_CACHE_HOME="${HELM_HOME}"
 fi
 
 # if HELM_CHART_NAME is not set, default to component name


### PR DESCRIPTION
- helm3 no longer uses HELM_HOME env var: https://helm.sh/docs/faq/#xdg-base-directory-support (causing users directories to be used otherwise)
- we don't need helm init for localdev in case of helm3

Signed-off-by: Hasan Turken <turkenh@gmail.com>