### PR TITLE
Support Go 1.15

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -51,7 +51,7 @@ GO_LDFLAGS += -s -w
 endif
 
 # supported go versions
-GO_SUPPORTED_VERSIONS ?= 1.7|1.8|1.9|1.10|1.11|1.12|1.13|1.14
+GO_SUPPORTED_VERSIONS ?= 1.7|1.8|1.9|1.10|1.11|1.12|1.13|1.14|1.15
 
 # set GOOS and GOARCH
 GOOS := $(OS)


### PR DESCRIPTION
I've confirmed Crossplane core builds and runs by running:

 ```console
$ go version
go version go1.15.3 darwin/amd64

$ GO_SUPPORTED_VERSIONS=1.15 make distclean clean test build
```