### PR TITLE
Remove lint from non-relevant places

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -300,7 +300,6 @@ do.build.artifacts: $(foreach p,$(PLATFORMS), do.build.artifacts.$(p))
 # build for all platforms
 build.all:
 	@$(MAKE) build.init
-	@$(MAKE) build.check
 	@$(MAKE) build.code
 	@$(MAKE) do.build.platform
 	@$(MAKE) build.artifacts

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -232,6 +232,11 @@ go.vendor:
 	@$(GOHOST) mod vendor || $(FAIL)
 	@$(OK) go mod vendor
 
+go.vendor.tidy:
+	@$(INFO) go mod tidy
+	@$(GOHOST) mod tidy || $(FAIL)
+	@$(OK) go mod tidy
+
 else
 
 go.vendor.lite: $(DEP)
@@ -277,7 +282,7 @@ go.generate:
 
 
 .PHONY: go.init go.build go.install go.test.unit go.test.integration go.test.codecov go.lint go.vet go.fmt go.generate
-.PHONY: go.validate go.vendor.lite go.vendor go.vendor.check go.vendor.update go.clean go.distclean
+.PHONY: go.validate go.vendor.lite go.vendor go.vendor.check go.vendor.tidy go.vendor.update go.clean go.distclean
 
 # ====================================================================================
 # Common Targets

--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -86,8 +86,10 @@ helm.prepare.$(1): $(HELM_HOME)
 helm.prepare: helm.prepare.$(1)
 
 helm.lint.$(1): $(HELM_HOME) helm.prepare.$(1)
+	@$(INFO) helm lint $(1)
 	@rm -rf $(abspath $(HELM_CHARTS_DIR)/$(1)/charts)
 	@$(HELM) lint $(abspath $(HELM_CHARTS_DIR)/$(1)) $(HELM_CHART_LINT_ARGS_$(1)) --strict
+	@$(OK) helm lint $(1)
 
 helm.lint: helm.lint.$(1)
 
@@ -153,8 +155,8 @@ $(foreach p,$(HELM_CHARTS),$(eval $(call museum.upload,$(p))))
 # ====================================================================================
 # Common Targets
 
-build.init: helm.prepare helm.lint
-build.check: helm.dep
+build.init: helm.prepare helm.dep
+build.check: helm.lint
 build.artifacts: helm.build
 clean: helm.clean
 lint: helm.lint


### PR DESCRIPTION
Remove lint jobs and targets from processes and targets which they don't necessarily need to run lint. Notable changes:

- `make build`: `make build.check` was removed from it
- `make helm.check`: new target added for linting helm chart
- `make go.vendor.tidy`: new target for `go mod tidy` which will be used in upstream projects' targets (e.g. `make reviewable`).

This PR blocks https://github.com/crossplane/crossplane/pull/1950 and should be reviewed as a pair.