### PR TITLE
Make helm3 version configurable

### DIFF
--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -38,7 +38,7 @@ KUSTOMIZE := $(TOOLS_HOST_DIR)/kustomize-$(KUSTOMIZE_VERSION)
 
 # the version of helm 3 to use
 USE_HELM3 ?= false
-HELM3_VERSION := v3.2.4
+HELM3_VERSION ?= v3.4.0
 HELM3 := $(TOOLS_HOST_DIR)/helm-$(HELM3_VERSION)
 
 # If we enable HELM3 we alias HELM to be HELM3

--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -38,7 +38,7 @@ KUSTOMIZE := $(TOOLS_HOST_DIR)/kustomize-$(KUSTOMIZE_VERSION)
 
 # the version of helm 3 to use
 USE_HELM3 ?= false
-HELM3_VERSION ?= v3.4.0
+HELM3_VERSION ?= v3.4.2
 HELM3 := $(TOOLS_HOST_DIR)/helm-$(HELM3_VERSION)
 
 # If we enable HELM3 we alias HELM to be HELM3


### PR DESCRIPTION
Due to the announcement form Helm https://helm.sh/blog/new-location-stable-incubator-charts/,
the new location for helm chart repository has been upgraded to Github Pages. We MUST update the
repositories we use before November 13, 2020. Helm v2.17.0 and v3.4.0 have been released to
help use the new location.

Signed-off-by: zzxwill <zzxwill@gmail.com>