### PR TITLE
Update default base image to alpine:3.12 and add support for armv6

### DIFF
--- a/makelib/image.mk
+++ b/makelib/image.mk
@@ -35,6 +35,8 @@ ifeq ($(ARCH),amd64)
 OSBASEIMAGE = $(OSBASE)
 else ifeq ($(ARCH),arm64)
 OSBASEIMAGE = arm64v8/$(OSBASE)
+else ifeq ($(ARCH),arm)
+OSBASEIMAGE = arm32v6/$(OSBASE)
 else
 $(error unsupported architecture $(ARCH))
 endif

--- a/makelib/image.mk
+++ b/makelib/image.mk
@@ -30,7 +30,7 @@ endif
 # set the OS base image to alpine if in not defined. set your own image for each
 # supported platform.
 ifeq ($(origin OSBASEIMAGE),undefined)
-OSBASE ?= alpine:3.7
+OSBASE ?= alpine:3.12
 ifeq ($(ARCH),amd64)
 OSBASEIMAGE = $(OSBASE)
 else ifeq ($(ARCH),arm64)


### PR DESCRIPTION
`alpine:3.7` is no longer supported, so we update to `alpine:3.12` as default, which also supports `armv6`. 32-bit arm golang builds default to `armv6` and we don't currently allow for overriding `GOARM` in `build` submodule.