### PR TITLE
Update awscli install method

### DIFF
--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -18,7 +18,6 @@ FROM ubuntu:16.04
 # install build and release tools
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yy -q --no-install-recommends \
-    python \
     build-essential \
     ca-certificates \
     curl \
@@ -38,10 +37,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # ------------------------------------------------------------------------------------------------
-# Install pip & AWSCLI
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python get-pip.py && \
-    pip install awscli --upgrade
+# Install AWSCLI
+RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.1.21.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip ./aws
 
 # ------------------------------------------------------------------------------------------------
 # Go support


### PR DESCRIPTION
- Uses current method to install `awscli`: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
- Pins `awscli` version to `2.1.21` to help with reproducible builds. 