### PR TITLE
Fix helm init issue related to stable repo

### DIFF
--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -63,7 +63,7 @@ HELM_CHART_VERSION := $(VERSION:v%=%)
 $(HELM_HOME): $(HELM)
 	@mkdir -p $(HELM_HOME)
 	@if [ "$(USE_HELM3)" == "false" ]; then \
-		$(HELM) init -c; \
+		$(HELM) init -c --stable-repo-url=https://charts.helm.sh/stable; \
 	fi
 
 $(HELM_OUTPUT_DIR):


### PR DESCRIPTION
Fixes the following errors related to the updated charts repo:
1. error initializing: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository
2. cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden