### PR TITLE
Allow build with mingw64

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -97,8 +97,11 @@ PLATFORMS ?= darwin_amd64 windows_amd64 linux_amd64 linux_arm64
 
 # Set the host's OS. Only linux and darwin supported for now
 HOSTOS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
-ifeq ($(filter darwin linux,$(HOSTOS)),)
-$(error build only supported on linux and darwin host currently)
+ifeq (mingw64_nt, $(word 1, $(subst -, ,$(HOSTOS))))
+HOSTOS := windows
+endif
+ifeq ($(filter darwin linux windows,$(HOSTOS)),)
+$(error build only supported on linux, darwin and mingw64 host currently. Detected system is $(HOSTOS))
 endif
 
 # Set the host's arch. Only amd64 support for now


### PR DESCRIPTION
The make process should allow build on windows using MINGW64 which provides a bash running on Windows (without WSL).

One issue is that MINGW64's built-in `uname` returns something like `MINGW64_NT-10.0-19041` in opposite to `linux` or `darwin` on other systems.

### Description of changes

1. In `common.mk` check if `HOSTOS` starts with `mingw64_nt` and if yes, set `HOSTOS := windows`
2. Add `windows` to allowed platforms
3. Continue as before

### How has the code been tested

Tested with https://github.com/crossplane/provider-aws using Make `4.3` and Golang `1.15.7`.