### PR TITLE
Build with Go 1.16.1, and remove the whitelist of supported versions

### DIFF
--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -45,8 +45,8 @@ RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.1.21.zip"
 
 # ------------------------------------------------------------------------------------------------
 # Go support
-RUN GO_VERSION=1.14.4 && \
-    GO_HASH=aed845e4185a0b2a3c3d5e1d0a35491702c55889192bb9c30e67a3de6849c067 && \
+RUN GO_VERSION=1.16.1 && \
+    GO_HASH=3edc22f8332231c3ba8be246f184b736b8d28f06ce24f08168d8ecf052549769 && \
     curl -fsSL https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz -o golang.tar.gz && \
     echo "${GO_HASH}  golang.tar.gz" | sha256sum -c - && \
     tar -C /usr/local -xzf golang.tar.gz && \

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -52,9 +52,6 @@ ifeq ($(DEBUG),0)
 GO_LDFLAGS += -s -w
 endif
 
-# supported go versions
-GO_SUPPORTED_VERSIONS ?= 1.7|1.8|1.9|1.10|1.11|1.12|1.13|1.14
-
 # set GOOS and GOARCH
 GOOS := $(OS)
 GOARCH := $(ARCH)
@@ -146,10 +143,6 @@ endif
 # Go Targets
 
 go.init: go.vendor.lite
-	@if ! `$(GO) version | grep -q -E '\bgo($(GO_SUPPORTED_VERSIONS))\b'`; then \
-		$(ERR) unsupported go version. Please make install one of the following supported version: '$(GO_SUPPORTED_VERSIONS)' ;\
-		exit 1 ;\
-	fi
 	@if [ "$(GO111MODULE)" != "on" ] && [ "$(realpath ../../../..)" !=  "$(realpath $(GOPATH))" ]; then \
 		$(WARN) the source directory is not relative to the GOPATH at $(GOPATH) or you are you using symlinks. The build might run into issue. Please move the source directory to be at $(GOPATH)/src/$(GO_PROJECT) ;\
 	fi


### PR DESCRIPTION
Closes https://github.com/upbound/build/pull/122

Per https://github.com/upbound/build/pull/122#discussion_r508284675, most (all?) of our projects now use Go modules, which allow a module to declare the version of Go it targets.

It could be that the purpose of this variable is to gate the versions of Go that `upbound/build` as a library of Makefiles supports, rather than the versions of Go that _code built with_ `upbound/build` supports. If this is the case, I'd argue that during the the two years I've been using this library we've yet to encounter a new version of Go that has required anything other than a bump to this whitelist and that we never test that the older versions of Go still work. I suspect it would be more productive to pay the price of a newer version of Go breaking the library if and when that becomes an issue than it currently is to bump the var every time a new version of Go is released.

Edit: I've now tested this by:

* Confirming I can build `crossplane/crossplane` with this PR, and Go 1.16.1.
* Confirming I can `make img.build && docker run <crosscontainer> go version` for the Cross container.