### PR TITLE
Option to disable helm strict linting

### DIFF
--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -35,6 +35,11 @@ HELM_OUTPUT_DIR ?= $(OUTPUT_DIR)/charts
 # the helm index file
 HELM_INDEX := $(HELM_OUTPUT_DIR)/index.yaml
 
+HELM_CHART_LINT_STRICT ?= true
+ifeq ($(HELM_CHART_LINT_STRICT),true)
+HELM_CHART_LINT_STRICT_ARG += --strict
+endif
+
 # helm home
 HELM_HOME := $(abspath $(WORK_DIR)/helm)
 export HELM_HOME
@@ -87,7 +92,7 @@ helm.prepare: helm.prepare.$(1)
 
 helm.lint.$(1): $(HELM_HOME) helm.prepare.$(1)
 	@rm -rf $(abspath $(HELM_CHARTS_DIR)/$(1)/charts)
-	@$(HELM) lint $(abspath $(HELM_CHARTS_DIR)/$(1)) $(HELM_CHART_LINT_ARGS_$(1)) --strict
+	@$(HELM) lint $(abspath $(HELM_CHARTS_DIR)/$(1)) $(HELM_CHART_LINT_ARGS_$(1)) $(HELM_CHART_LINT_STRICT_ARG)
 
 helm.lint: helm.lint.$(1)
 

--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -78,14 +78,14 @@ $(ISTIO):
 $(KIND):
 	@$(INFO) installing kind $(KIND_VERSION)
 	@mkdir -p $(TOOLS_HOST_DIR) || $(FAIL)
-	@curl -fsSLo $(KIND) https://github.com/kubernetes-sigs/kind/releases/download/$(KIND_VERSION)/kind-$(GOHOSTOS)-$(GOHOSTARCH) || $(FAIL)
+	@curl -fsSLo $(KIND) https://github.com/kubernetes-sigs/kind/releases/download/$(KIND_VERSION)/kind-$(HOSTOS)-$(HOSTARCH) || $(FAIL)
 	@chmod +x $(KIND) 
 	@$(OK) installing kind $(KIND_VERSION)
 
 # kubectl download and install
 $(KUBECTL):
 	@$(INFO) installing kubectl $(KUBECTL_VERSION)
-	@curl -fsSLo $(KUBECTL) https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VERSION)/bin/$(GOHOSTOS)/$(GOHOSTARCH)/kubectl || $(FAIL)
+	@curl -fsSLo $(KUBECTL) https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VERSION)/bin/$(HOSTOS)/$(HOSTARCH)/kubectl || $(FAIL)
 	@chmod +x $(KUBECTL) 
 	@$(OK) installing kubectl $(KUBECTL_VERSION)
 

--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -38,7 +38,7 @@ KUSTOMIZE := $(TOOLS_HOST_DIR)/kustomize-$(KUSTOMIZE_VERSION)
 
 # the version of helm 3 to use
 USE_HELM3 ?= false
-HELM3_VERSION ?= v3.4.2
+HELM3_VERSION ?= v3.5.3
 HELM3 := $(TOOLS_HOST_DIR)/helm-$(HELM3_VERSION)
 
 # If we enable HELM3 we alias HELM to be HELM3

--- a/scripts/localdev-deploy-component.sh
+++ b/scripts/localdev-deploy-component.sh
@@ -66,9 +66,9 @@ if [ "${LOCALDEV_LOCAL_BUILD}" == "true" ] && containsElement "${HELM_CHART_NAME
   [ -f "${HELM_CHART_REF}" ] || echo_error "Local chart ${HELM_CHART_REF} not found. Did you run \"make build\" ? "
 
   # If local build, tag "required" local images, so that they can be load into kind cluster at a later step.
-  for r in "${registries_arr[@]}"; do
-    for i in "${images_arr[@]}"; do
-      for a in "${image_archs_arr[@]}"; do
+  for r in ${registries_arr[@]+"${registries_arr[@]}"}; do
+    for i in ${images_arr[@]+"${images_arr[@]}"}; do
+      for a in ${image_archs_arr[@]+"${image_archs_arr[@]}"}; do
         if containsElement "${r}/${i}" ${REQUIRED_IMAGES[@]+"${REQUIRED_IMAGES[@]}"}; then
           echo_info "Tagging locally built image as ${r}/${i}:${VERSION}"
           docker tag "${BUILD_REGISTRY}/${i}-${a}" "${r}/${i}:${VERSION}"


### PR DESCRIPTION
This PR adds an option to disable strict helm linting which fails the build with warnings. Ideally, we should fix warnings instead of disabling strict linting, however, sometimes this is not possible (or does not make sense) like an incorrect warning on the helm side. 

Currently, [this issue](https://github.com/helm/helm/issues/9197) on helm side prevents use prevents us using helm 3 with Crossplane chart. With this option, we will be able to (temporarily) disable strict linting.

This PR also updates helm version to latest (v3.5.3) which includes PRs fixing[ categorization of linting issues ](https://github.com/helm/helm/issues/8596)as warnings instead of errors.