### PR TITLE
Support publishing images from main

### DIFF
--- a/makelib/image.mk
+++ b/makelib/image.mk
@@ -235,8 +235,9 @@ clean: img.clean img.release.clean
 
 publish.init: img.release.build
 
-# only publish images for master and release branches
-ifneq ($(filter master release-%,$(BRANCH_NAME)),)
+# only publish images for main / master and release branches
+# TODO(hasheddan): remove master and support overriding
+ifneq ($(filter main master release-%,$(BRANCH_NAME)),)
 publish.artifacts: $(addprefix img.release.manifest.publish.,$(IMAGES))
 endif
 


### PR DESCRIPTION
Allows for publishing images from branches named main.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>