### PR TITLE
build dockerfile using newer ubuntu release

### DIFF
--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # ------------------------------------------------------------------------------------------------
 # install build and release tools


### PR DESCRIPTION
Build environment should use newer ubuntu release
Xenial is EOL on 4/2021 - https://help.ubuntu.com/community/EOL#Ubuntu_16.04_Xenial_Xerus
Was able to build this dockerfile locally without issue.
Ex. `docker build --build-arg TINI_VERSION=v0.19.0 --build-arg ARCH=amd64 .`
Signed-off-by: smcavallo <smcavallo@hotmail.com>