### PR TITLE
Fix syntax error when building Go test packages

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -150,7 +150,7 @@ go.init: go.vendor.lite
 go.build:
 	@$(INFO) go build $(PLATFORM)
 	$(foreach p,$(GO_STATIC_PACKAGES),@CGO_ENABLED=0 $(GO) build -v -i -o $(GO_OUT_DIR)/$(lastword $(subst /, ,$(p)))$(GO_OUT_EXT) $(GO_STATIC_FLAGS) $(p) || $(FAIL) ${\n})
-	$(foreach p,$(GO_TEST_PACKAGES) $(GO_LONGHAUL_TEST_PACKAGES),@CGO_ENABLED=0 $(GO) test -i -c -o $(GO_TEST_OUTPUT)/$(lastword $(subst /, ,$(p)))$(GO_OUT_EXT) $(GO_STATIC_FLAGS) $(p) || $(FAIL ${\n}))
+	$(foreach p,$(GO_TEST_PACKAGES) $(GO_LONGHAUL_TEST_PACKAGES),@CGO_ENABLED=0 $(GO) test -i -c -o $(GO_TEST_OUTPUT)/$(lastword $(subst /, ,$(p)))$(GO_OUT_EXT) $(GO_STATIC_FLAGS) $(p) || $(FAIL) ${\n})
 	@$(OK) go build $(PLATFORM)
 
 go.install:


### PR DESCRIPTION
This currently results in make spitting out a fairly opaque EOF error from bash:

```console
$ make
01:08:51 [ .. ] verify dependencies have expected content
all modules verified
01:08:51 [ OK ] go modules dependencies verified
01:08:51 [ .. ] golangci-lint
01:08:51 [ OK ] golangci-lint
01:08:52 [ .. ] go build linux_amd64
/bin/bash: -c: line 1: syntax error: unexpected end of file
make[3]: *** [build/makelib/golang.mk:153: go.build] Error 1
make[2]: *** [build/makelib/common.mk:292: do.build.platform.linux_amd64] Error 2
make[1]: *** [build/makelib/common.mk:305: build.all] Error 2
make: *** [build/makelib/common.mk:313: build] Error 2
```

I've verified that with this change things proceed as expected!