### PR TITLE
image.mk: replace the last remainingn HOSTARCH usage with SAFEHOSTARCH

### DIFF
--- a/makelib/image.mk
+++ b/makelib/image.mk
@@ -283,6 +283,6 @@ help-special: img.help
 $(MANIFEST_TOOL):
 	@$(INFO) installing manifest-tool $(HOST_PLATFORM)
 	@mkdir -p $(TOOLS_HOST_DIR) || $(FAIL)
-	@curl -fsSL https://github.com/estesp/manifest-tool/releases/download/$(MANIFEST_TOOL_VERSION)/manifest-tool-$(HOSTOS)-$(HOSTARCH) > $@ || $(FAIL)
+	@curl -fsSL https://github.com/estesp/manifest-tool/releases/download/$(MANIFEST_TOOL_VERSION)/manifest-tool-$(HOSTOS)-$(SAFEHOSTARCH) > $@ || $(FAIL)
 	@chmod +x $@ || $(FAIL)
 	@$(OK) installing manifest-tool $(HOST_PLATFORM)


### PR DESCRIPTION
This is required, otherwise artifacts cannot be published https://github.com/crossplane/provider-aws/runs/2488167717?check_suite_focus=true