### PR TITLE
Allow publishing to channel main

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -73,8 +73,9 @@ DEBUG ?= 0
 # ====================================================================================
 # Releae Options
 
+# TODO(hasheddan): change default to main and remove master as valid option.
 CHANNEL ?= master
-ifeq ($(filter master alpha beta stable,$(CHANNEL)),)
+ifeq ($(filter master main alpha beta stable,$(CHANNEL)),)
 $(error invalid channel $(CHANNEL))
 endif
 
@@ -440,7 +441,7 @@ Release Targets:
 
 Release Options:
     VERSION      The version information for binaries and releases.
-    CHANNEL      Sets the release channel. Can be set to master, alpha, beta, or stable.
+    CHANNEL      Sets the release channel. Can be set to master, main, alpha, beta, or stable.
 
 endef
 export HELPTEXT

--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -71,7 +71,7 @@ endif
 DEBUG ?= 0
 
 # ====================================================================================
-# Releae Options
+# Release Options
 
 # TODO(hasheddan): change default to main and remove master as valid option.
 CHANNEL ?= master


### PR DESCRIPTION
Adds main as a list of suitable channels for publishing output
artifacts.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #147 

(some context: https://github.com/upbound/up/blob/8aad71f5f04b7354cd31141ff193528d911c1b44/.github/workflows/ci.yml#L280)