### PR TITLE
Fix version for two hypens in tag

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -210,10 +210,10 @@ ifeq ($(origin VERSION), undefined)
 # check if there are any existing `git tag` values
 ifeq ($(shell git tag),)
 # no tags found - default to initial tag `v0.0.0`
-VERSION := $(shell echo "v0.0.0-$$(git rev-list HEAD --count)-g$$(git describe --dirty --always)" | sed 's/-/./2' | sed 's/-/./2')
+VERSION := $(shell echo "v0.0.0-$$(git rev-list HEAD --count)-g$$(git describe --dirty --always)" | sed 's/-/./2' | sed 's/-/./2' | sed 's/-/./2')
 else
 # use tags
-VERSION := $(shell git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )
+VERSION := $(shell git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' | sed 's/-/./2' )
 endif
 endif
 export VERSION


### PR DESCRIPTION
When the tag contains two hyphens, we end up generating versions not sortable as semver. See https://github.com/upbound/universal-crossplane/issues/109 for more details.

This PR fixes that by converting `-` to `.` in that case just like we do other hyphens in `git describe` output.

Signed-off-by: Hasan Turken <turkenh@gmail.com>