### PR TITLE
Add a common `make reviewable` target

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -418,7 +418,13 @@ reviewable:
 	@$(MAKE) lint
 	@$(MAKE) test
 
-.PHONY: publish.init publish.artifacts publish promote.init promote.artifacts promote tag generate reviewable
+# ensure reviewable target doesn't create a diff
+check-diff: reviewable
+	@$(INFO) checking that branch is clean
+	@test -z "$(shell git status --porcelain)"" || $(FAIL)
+	@$(OK) branch is clean
+
+.PHONY: publish.init publish.artifacts publish promote.init promote.artifacts promote tag generate reviewable check-diff
 
 # ====================================================================================
 # Help
@@ -437,6 +443,7 @@ Common Targets:
     e2e          Runs end-to-end integration tests.
 	generate     Run code generation.
 	reviewable   Validate that a PR is ready for review.
+	check-diff   Ensure the reviewable target doesn't create a git diff.
 
 Common Options:
     DEBUG        Whether to generate debug symbols. Default is 0.

--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -425,8 +425,8 @@ reviewable:
 	@$(MAKE) lint
 	@$(MAKE) test
 
-# ensure reviewable target doesn't create a diff
-check-diff: reviewable
+# ensure generate target doesn't create a diff
+check-diff: generate
 	@$(INFO) checking that branch is clean
 	@test -z "$(shell git status --porcelain)" || $(FAIL)
 	@$(OK) branch is clean

--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -409,7 +409,16 @@ promote:
 # tag a release
 tag: release.tag
 
-.PHONY: publish.init publish.artifacts publish promote.init promote.artifacts promote tag
+# run code generation
+generate: ; @:
+
+# prepare for code review
+reviewable:
+	@$(MAKE) generate
+	@$(MAKE) lint
+	@$(MAKE) test
+
+.PHONY: publish.init publish.artifacts publish promote.init promote.artifacts promote tag generate reviewable
 
 # ====================================================================================
 # Help
@@ -426,6 +435,8 @@ Common Targets:
     help         Show this help info.
     test         Runs unit tests.
     e2e          Runs end-to-end integration tests.
+	generate     Run code generation.
+	reviewable   Validate that a PR is ready for review.
 
 Common Options:
     DEBUG        Whether to generate debug symbols. Default is 0.

--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -428,7 +428,7 @@ reviewable:
 # ensure reviewable target doesn't create a diff
 check-diff: reviewable
 	@$(INFO) checking that branch is clean
-	@test -z "$(shell git status --porcelain)"" || $(FAIL)
+	@test -z "$(shell git status --porcelain)" || $(FAIL)
 	@$(OK) branch is clean
 
 .PHONY: publish.init publish.artifacts publish promote.init promote.artifacts promote tag generate reviewable check-diff

--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -448,9 +448,9 @@ Common Targets:
     help         Show this help info.
     test         Runs unit tests.
     e2e          Runs end-to-end integration tests.
-	generate     Run code generation.
-	reviewable   Validate that a PR is ready for review.
-	check-diff   Ensure the reviewable target doesn't create a git diff.
+    generate     Run code generation.
+    reviewable   Validate that a PR is ready for review.
+    check-diff   Ensure the reviewable target doesn't create a git diff.
 
 Common Options:
     DEBUG        Whether to generate debug symbols. Default is 0.

--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -410,7 +410,14 @@ promote:
 tag: release.tag
 
 # run code generation
-generate: ; @:
+generate.init: ; @:
+generate.run: ; @:
+generate.done: ; @:
+
+generate:
+	@$(MAKE) generate.init
+	@$(MAKE) generate.run
+	@$(MAKE) generate.done
 
 # prepare for code review
 reviewable:

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -269,8 +269,6 @@ go.generate:
 	@$(INFO) go generate $(PLATFORM)
 	@CGO_ENABLED=0 $(GOHOST) generate $(GO_GENERATE_FLAGS) $(GO_PACKAGES) $(GO_INTEGRATION_TEST_PACKAGES) || $(FAIL)
 	@$(OK) go generate $(PLATFORM)
-
-go.reviewable:
 	@$(INFO) go mod tidy
 	@$(GOHOST) mod tidy || $(FAIL)
 	@$(OK) go mod tidy

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -290,6 +290,8 @@ lint.init: go.init
 lint.run: go.lint
 test.init: go.init
 test.run: go.test.unit
+generate.init: go.init
+generate.run: go.generate
 
 # ====================================================================================
 # Special Targets
@@ -302,7 +304,6 @@ vendor: go.vendor
 vendor.check: go.vendor.check
 vendor.update: go.vendor.update
 vet: go.vet
-generate codegen: go.generate
 
 define GO_HELPTEXT
 Go Targets:

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -270,6 +270,10 @@ go.generate:
 	@CGO_ENABLED=0 $(GOHOST) generate $(GO_GENERATE_FLAGS) $(GO_PACKAGES) $(GO_INTEGRATION_TEST_PACKAGES) || $(FAIL)
 	@$(OK) go generate $(PLATFORM)
 
+go.reviewable:
+	@$(INFO) go mod tidy
+	@$(GOHOST) mod tidy || $(FAIL)
+	@$(OK) go mod tidy
 
 .PHONY: go.init go.build go.install go.test.unit go.test.integration go.test.codecov go.lint go.vet go.fmt go.generate
 .PHONY: go.validate go.vendor.lite go.vendor go.vendor.check go.vendor.update go.clean go.distclean

--- a/makelib/local.mk
+++ b/makelib/local.mk
@@ -159,7 +159,6 @@ vendor: go.vendor
 vendor.check: go.vendor.check
 vendor.update: go.vendor.update
 vet: go.vet
-generate codegen: go.generate
 
 define LOCAL_HELPTEXT
 Local Targets:


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

We've been using this target in Crossplane projects for some time. The idea is that's it's a one-shot folks can run to validate that their branch is not likely to fail CI when they open a branch, by ensuring codegen has run, and that any linters and tests pass.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

I've validated that this works with crossplane/crossplane (with a few tweaks to its own `Makefile`).