### PR TITLE
go: do not run go.lint for every build

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -281,7 +281,6 @@ go.generate:
 # Common Targets
 
 build.init: go.init
-build.check: go.lint
 build.code.platform: go.build
 clean: go.clean
 distclean: go.distclean


### PR DESCRIPTION
### Description of your changes

`go.lint` takes quite a while for big repositories like provider-aws but it's actually not relevant for building. The check is done by other mechanisms like `make reviewable` when necessary. This PR removes the `go.lint` from the `build` target.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manually with provider-aws

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
