### PR TITLE
Adds support for darwin amd64 and arm64

### DIFF
--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -55,7 +55,7 @@ ENV PATH /usr/local/go/bin:$PATH
 
 # precompile the go standard library for all supported platforms and configurations
 # the install suffixes match those in golang.mk so please keep them in sync
-RUN platforms="darwin_amd64 windows_amd64 linux_amd64 linux_arm64" && \
+RUN platforms="darwin_amd64 darwin_arm64 windows_amd64 linux_amd64 linux_arm64" && \
     for p in $platforms; do CGO_ENABLED=0 GOOS=${p%_*} GOARCH=${p##*_} GOARM=7 go install -installsuffix static -a std; done
 
 # ------------------------------------------------------------------------------------------------

--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -105,13 +105,6 @@ endif
 # Set the host's arch.
 HOSTARCH := $(shell uname -m)
 
-# Set safe architectures for supported OSes (darwin and linux).
-# Apple Silicon binaries are not widely available yet
-ifeq ($(HOSTOS),darwin)
-SAFEHOSTARCH := amd64
-TARGETARCH := $(HOSTARCH)
-endif
-
 # If SAFEHOSTARCH and TARGETARCH have not been defined yet, use HOST
 ifeq ($(origin SAFEHOSTARCH),undefined)
 SAFEHOSTARCH := $(HOSTARCH)

--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -105,6 +105,13 @@ endif
 # Set the host's arch.
 HOSTARCH := $(shell uname -m)
 
+# Set safe architectures for supported OSes (darwin and linux).
+# Apple Silicon binaries are not widely available yet
+ifeq ($(HOSTOS),darwin)
+SAFEHOSTARCH := amd64
+TARGETARCH := $(HOSTARCH)
+endif
+
 # If SAFEHOSTARCH and TARGETARCH have not been defined yet, use HOST
 ifeq ($(origin SAFEHOSTARCH),undefined)
 SAFEHOSTARCH := $(HOSTARCH)

--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -25,7 +25,7 @@ ISTIO_DOWNLOAD_TUPLE := osx
 endif
 
 # the version of kind to use
-KIND_VERSION ?= v0.9.0
+KIND_VERSION ?= v0.11.1
 KIND := $(TOOLS_HOST_DIR)/kind-$(KIND_VERSION)
 
 # the version of kubectl to use


### PR DESCRIPTION
Signed-off-by: Taylor Thornton <taylor@upbound.io>

### Description of your changes

The current build submodule makes an effort to not use darwin_arm64. Unfortunately, being on an Apple M1 MBP, that makes it so certain builds don't quite work.

In addition to the script updates, I upgraded kind as the earlier version defined would result in:
```
ERROR: failed to create cluster: failed to init node with kubeadm: command "docker exec --privileged build-07a4805a-inttests-control-plane kubeadm init --skip-phases=preflight --config=/kind/kubeadm.conf --skip-token-print --v=6" failed with error: exit status 139
Command Output: SIGSEGV: segmentation violation
PC=0x0 m=0 sigcode=0

goroutine 1 [running]:
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
```
when running `make e2e` on crossplane/crossplane.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

These changes are coming in from a local branch I was using to get crossplane tests to work, specifically:
```
make
make test
make e2e
```
