### PR TITLE
Add dep update step so that charts with subcharts don't fail linting

### DIFF
--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -92,6 +92,7 @@ helm.prepare: helm.prepare.$(1)
 
 helm.lint.$(1): $(HELM_HOME) helm.prepare.$(1)
 	@rm -rf $(abspath $(HELM_CHARTS_DIR)/$(1)/charts)
+	@$(HELM) dependency update $(abspath $(HELM_CHARTS_DIR)/$(1))
 	@$(HELM) lint $(abspath $(HELM_CHARTS_DIR)/$(1)) $(HELM_CHART_LINT_ARGS_$(1)) $(HELM_CHART_LINT_STRICT_ARG)
 
 helm.lint: helm.lint.$(1)


### PR DESCRIPTION
### Description of your changes

In Helm3, the linting rules have changed slightly. Now if you have a dependency defined in your Chart.yaml, but don't have a corresponding subchart directory, linting will fail. This change adds a step to ensure helm has the full view of the dependencies when it attempts linting.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
Locally on the enterprise-server repo.
