### PR TITLE
Add helm repo add step if internal_museum_url is defined

### DIFF
--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -84,6 +84,11 @@ $(HELM_OUTPUT_DIR)/$(1)-$(HELM_CHART_VERSION).tgz: $(HELM_HOME) $(HELM_OUTPUT_DI
 	fi
 	@$(OK) helm package $(1) $(HELM_CHART_VERSION)
 
+helm.repo.add:
+ifdef INTERNAL_MUSEUM_URL
+	@$(HELM) repo add $(INTERNAL_MUSEUM_NAME) $(INTERNAL_MUSEUM_URL) --username $(INTERNAL_MUSEUM_USER) --password $(INTERNAL_MUSEUM_PASS)
+endif
+
 helm.prepare.$(1): $(HELM_HOME)
 	@cp -f $(HELM_CHARTS_DIR)/$(1)/values.yaml.tmpl $(HELM_CHARTS_DIR)/$(1)/values.yaml
 	@cd $(HELM_CHARTS_DIR)/$(1) && $(SED_CMD) 's|%%VERSION%%|$(VERSION)|g' values.yaml
@@ -159,7 +164,7 @@ $(foreach p,$(HELM_CHARTS),$(eval $(call museum.upload,$(p))))
 # ====================================================================================
 # Common Targets
 
-build.init: helm.prepare helm.lint
+build.init: helm.repo.add helm.prepare helm.lint
 build.check: helm.dep
 build.artifacts: helm.build
 clean: helm.clean


### PR DESCRIPTION
### Description of your changes
This change adds an additional init step that adds our internal helm chart museum as a repo. We do this to enable authenticated requests to it in the event the `INTERNAL_MUSEUM_URL` is defined, as is the case with enterprise-server.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
Primarily tested in the enterprise-server repo. Both disabled, i.e. not specifying `INTERNAL_MUSEUM_URL` and verifying that issuing `make` did not result in error as well as specifying `INTERNAL_MUSEUM_URL` and verifying that the `helm repo add` command was executed and the desired `pull` behavior was seen when the accompanying _USER and _PASS env vars we're also configured.
