### PR TITLE
Optionally publish a valid docs version

### DIFF
--- a/makelib/docs.mk
+++ b/makelib/docs.mk
@@ -27,6 +27,10 @@ ifndef DOCS_GIT_REPO
 $(error DOCS_GIT_REPO must be defined)
 endif
 
+# Optional. If false the publish step will remove this version from the
+# documentation repository.
+DOCS_VERSION_ACTIVE ?= true
+
 DOCS_VERSION := $(shell echo "$(BRANCH_NAME)" | sed -E "s/^release\-([0-9]+)\.([0-9]+)$$/v\1.\2/g")
 DOCS_WORK_DIR := $(WORK_DIR)/docs-repo
 DOCS_VERSION_DIR := $(DOCS_WORK_DIR)/$(DEST_DOCS_DIR)/$(DOCS_VERSION)
@@ -39,7 +43,11 @@ docs.publish:
 	mkdir -p $(DOCS_WORK_DIR)
 	git clone --depth=1 -b master $(DOCS_GIT_REPO) $(DOCS_WORK_DIR)
 	rm -rf $(DOCS_VERSION_DIR)
-	cp -r $(SOURCE_DOCS_DIR)/ $(DOCS_VERSION_DIR)
+	@if [ "$(DOCS_VERSION_ACTIVE)" == "true" ]; then \
+		$(INFO) Including version in documentation ; \
+		cp -r $(SOURCE_DOCS_DIR)/ $(DOCS_VERSION_DIR); \
+		$(OK) Version included in documentation ; \
+	fi
 	cd $(DOCS_WORK_DIR) && DOCS_VERSION=$(DOCS_VERSION) $(MAKE) publish
 
 # ====================================================================================


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds a flag to indicate that a certain version of the documentation
should not be published. If DOCS_VERSION_ACTIVE is set to false, the
version will be removed from documentation if it exists. This
effectively allows a given release branch to be retired by adding this
flag and merging the commit.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

xref https://github.com/crossplane/crossplane.github.io/issues/107

**How this works**: when a release branch goes out of support, we will add a formalized process that includes opening a PR to the branch adding `DOCS_VERSION_ACTIVE = false` to the `Makefile`. When that PR is merged, it will trigger a docs build and publish, which will remove all of the docs for that branch, then [update the `versions.json`](https://github.com/crossplane/crossplane.github.io/blob/c3139c917ead9b8c1cf0d5d783ad4c6be5fc7483/preprocess.js#L34) (which builds our dropdown on the docs site).

_NOTE: for all the currently listed versions that are included in our docs, I am going to manually remove them in a PR to the docs repo so that we don't have to go through pain of updating to this version to the build submodule for each of those very old branches. We cans start using the flag when `release-1.1` is dropped in the coming weeks._

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->


I tried this out on Crossplane `master` and exercised both scenarios:
1. Using this fork of build submodule and not setting flag:

_No changes detected so publishing skipped per [this logic](https://github.com/crossplane/crossplane.github.io/blob/c3139c917ead9b8c1cf0d5d783ad4c6be5fc7483/Makefile#L45)._

```
🤖 (crossplane) make docs.publish
rm -rf /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo
mkdir -p /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo
git clone --depth=1 -b master https://:@github.com/crossplane/crossplane.github.io.git /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo
Cloning into '/home/dan/code/github.com/crossplane/crossplane/.work/docs-repo'...
warning: redirecting to https://github.com/crossplane/crossplane.github.io.git/
remote: Enumerating objects: 979, done.
remote: Counting objects: 100% (979/979), done.
remote: Compressing objects: 100% (708/708), done.
remote: Total 979 (delta 411), reused 616 (delta 197), pack-reused 0
Receiving objects: 100% (979/979), 14.34 MiB | 39.46 MiB/s, done.
Resolving deltas: 100% (411/411), done.
rm -rf /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo/docs/master
13:28:35 [ .. ] Including version in documentation
13:28:35 [ OK ] Version included in documentation
cd /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo && DOCS_VERSION=master make publish
npm install
npm WARN crossplane.github.io@1.0.0 No repository field.

added 4 packages from 2 contributors and audited 4 packages in 0.676s
found 0 vulnerabilities

node preprocess.js
git -C "/home/dan/code/github.com/crossplane/crossplane/.work/docs-repo" add -A
no changes detected

```

2. With `DOCS_VERSION_ACTIVE = false` in Crossplane `Makefile`:

_Master docs removed from docs repo._

```
🤖 (crossplane) make docs.publish
rm -rf /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo
mkdir -p /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo
git clone --depth=1 -b master https://:@github.com/crossplane/crossplane.github.io.git /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo
Cloning into '/home/dan/code/github.com/crossplane/crossplane/.work/docs-repo'...
warning: redirecting to https://github.com/crossplane/crossplane.github.io.git/
remote: Enumerating objects: 979, done.
remote: Counting objects: 100% (979/979), done.
remote: Compressing objects: 100% (708/708), done.
remote: Total 979 (delta 411), reused 616 (delta 197), pack-reused 0
Receiving objects: 100% (979/979), 14.34 MiB | 39.04 MiB/s, done.
Resolving deltas: 100% (411/411), done.
rm -rf /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo/docs/master
cd /home/dan/code/github.com/crossplane/crossplane/.work/docs-repo && DOCS_VERSION=master make publish
npm install
npm WARN crossplane.github.io@1.0.0 No repository field.

added 4 packages from 2 contributors and audited 4 packages in 0.588s
found 0 vulnerabilities

node preprocess.js
git -C "/home/dan/code/github.com/crossplane/crossplane/.work/docs-repo" add -A
committing changes...
[master 366705f] docs snapshot for crossplane version `master`
 78 files changed, 9260 deletions(-)
 delete mode 100644 docs/master/README.md
 delete mode 100644 docs/master/api-docs/crds/meta.pkg.crossplane.io_configurations.yaml
 delete mode 100644 docs/master/api-docs/crds/meta.pkg.crossplane.io_providers.yaml
 delete mode 100644 docs/master/api-docs/crossplane.md
 delete mode 100644 docs/master/api-docs/overview.md
 delete mode 100644 docs/master/api-docs/provider-alibaba.md
 delete mode 100644 docs/master/api-docs/provider-aws.md
 delete mode 100644 docs/master/api-docs/provider-azure.md
 delete mode 100644 docs/master/api-docs/provider-gcp.md
 delete mode 100644 docs/master/api-docs/provider-helm.md
 delete mode 100644 docs/master/api-docs/provider-rook.md
 delete mode 100644 docs/master/cloud-providers/aws/aws-provider.md
 delete mode 100644 docs/master/cloud-providers/azure/azure-provider.md
 delete mode 100644 docs/master/cloud-providers/gcp/gcp-provider.md
 delete mode 100644 docs/master/concepts/composition-concepts.png
 delete mode 100644 docs/master/concepts/composition-provisioning.png
 delete mode 100644 docs/master/concepts/composition.md
 delete mode 100644 docs/master/concepts/crossplane-concepts.png
 delete mode 100644 docs/master/concepts/managed-resources.md
 delete mode 100644 docs/master/concepts/overview.md
 delete mode 100644 docs/master/concepts/packages.md
 delete mode 100644 docs/master/concepts/providers.md
 delete mode 100644 docs/master/concepts/terminology.md
 delete mode 100644 docs/master/contributing/observability_developer_guide.md
 delete mode 100644 docs/master/contributing/onduty.md
 delete mode 100644 docs/master/contributing/overview.md
 delete mode 100644 docs/master/contributing/provider_development_guide.md
 delete mode 100644 docs/master/contributing/release-process.md
 delete mode 100644 docs/master/faqs/faqs.md
 delete mode 100644 docs/master/faqs/related_projects.md
 delete mode 100644 docs/master/getting-started/create-configuration.md
 delete mode 100644 docs/master/getting-started/install-configure.md
 delete mode 100644 docs/master/getting-started/provision-infrastructure.md
 delete mode 100644 docs/master/guides/composition-revisions.md
 delete mode 100644 docs/master/guides/direct-managed.md
 delete mode 100644 docs/master/guides/guides.md
 delete mode 100644 docs/master/guides/multi-tenant.md
 delete mode 100644 docs/master/guides/upgrading-to-v0.14.md
 delete mode 100644 docs/master/guides/upgrading-to-v1.x.md
 delete mode 100644 docs/master/guides/vault-injection.md
 delete mode 100644 docs/master/media/arch.png
 delete mode 100644 docs/master/media/banner.png
 delete mode 100644 docs/master/media/crossplane-overview.png
 delete mode 100644 docs/master/media/logo.svg
 delete mode 100644 docs/master/media/run-applications-dash.png
 delete mode 100644 docs/master/media/run-applications-diagram.jpg
 delete mode 100644 docs/master/media/run-applications-flights.png
 delete mode 100644 docs/master/reference/configure.md
 delete mode 100644 docs/master/reference/install.md
 delete mode 100644 docs/master/reference/learn_more.md
 delete mode 100644 docs/master/reference/overview.md
 delete mode 100644 docs/master/reference/release-cycle.md
 delete mode 100644 docs/master/reference/troubleshoot.md
 delete mode 100644 docs/master/reference/uninstall.md
 delete mode 100644 docs/master/snippets/compose/claim-aws.yaml
 delete mode 100644 docs/master/snippets/compose/claim-azure.yaml
 delete mode 100644 docs/master/snippets/compose/claim-gcp.yaml
 delete mode 100644 docs/master/snippets/compose/pod.yaml
 delete mode 100644 docs/master/snippets/configure/aws/providerconfig.yaml
 delete mode 100755 docs/master/snippets/configure/aws/setup.sh
 delete mode 100644 docs/master/snippets/configure/azure/providerconfig.yaml
 delete mode 100755 docs/master/snippets/configure/gcp/credentials.sh
 delete mode 100644 docs/master/snippets/package/aws-with-vpc/composition.yaml
 delete mode 100644 docs/master/snippets/package/aws-with-vpc/crossplane.yaml
 delete mode 100644 docs/master/snippets/package/aws-with-vpc/definition.yaml
 delete mode 100644 docs/master/snippets/package/aws/composition.yaml
 delete mode 100644 docs/master/snippets/package/aws/crossplane.yaml
 delete mode 100644 docs/master/snippets/package/aws/definition.yaml
 delete mode 100644 docs/master/snippets/package/azure/composition.yaml
 delete mode 100644 docs/master/snippets/package/azure/crossplane.yaml
 delete mode 100644 docs/master/snippets/package/azure/definition.yaml
 delete mode 100644 docs/master/snippets/package/definition.yaml
 delete mode 100644 docs/master/snippets/package/gcp/composition.yaml
 delete mode 100644 docs/master/snippets/package/gcp/crossplane.yaml
 delete mode 100644 docs/master/snippets/package/gcp/definition.yaml
 delete mode 100644 docs/master/snippets/provision/aws.yaml
 delete mode 100644 docs/master/snippets/provision/azure.yaml
 delete mode 100644 docs/master/snippets/provision/gcp.yaml
pushing changes...
remote: No anonymous write access.
fatal: Authentication failed for 'https://github.com/crossplane/crossplane.github.io.git/'
crossplane.github.io changes published
```