### PR TITLE
feat(check-diff): generate check-diff output

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -428,7 +428,7 @@ reviewable:
 # ensure generate target doesn't create a diff
 check-diff: generate
 	@$(INFO) checking that branch is clean
-	@test -z "$(shell git status --porcelain)" || $(FAIL)
+	@git status --porcelain | grep . && $(FAIL)
 	@$(OK) branch is clean
 
 .PHONY: publish.init publish.artifacts publish promote.init promote.artifacts promote tag generate reviewable check-diff


### PR DESCRIPTION
Signed-off-by: Christopher Haar <chhaar30@googlemail.com>

### Description of your changes

show check-diff modified output for specific files

old:
```
10:44:14 [ .. ] checking that branch is clean
10:44:14 [FAIL]
make: *** [check-diff] Error 1
```

new:
```
10:50:25 [ .. ] checking that branch is clean
 M build
 M package/crds/xxx.aws.crossplane.io_xyz.yaml
 M package/crds/xxx.aws.crossplane.io_abc.yaml
10:50:25 [FAIL]
```

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
via crossplane/provider-aws