### PR TITLE
Use ARCH not TARGETARCH when selecting base image

### DIFF
--- a/makelib/image.mk
+++ b/makelib/image.mk
@@ -31,12 +31,12 @@ endif
 # supported platform.
 ifeq ($(origin OSBASEIMAGE),undefined)
 OSBASE ?= alpine:3.13
-ifeq ($(TARGETARCH),$(filter $(TARGETARCH),amd64 ppc64le))
+ifeq ($(ARCH),$(filter $(ARCH),amd64 ppc64le))
 OSBASEIMAGE = $(OSBASE)
-else ifeq ($(TARGETARCH),arm64)
+else ifeq ($(ARCH),arm64)
 OSBASEIMAGE = arm64v8/$(OSBASE)
 else
-$(error unsupported architecture $(TARGETARCH))
+$(error unsupported architecture $(ARCH))
 endif
 endif
 


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

We previously switched to using TARGETARCH when selecting the platform
for the base image used when building images in a repository. TARGETARCH
was added to work around building locally on Apple arm64 machines, and
the machinery that was implemented at that time caused TARGETARCH to be
derived from the HOSTARCH, even when a PLATFORM was specified for
building. This means that we now use an amd64 base image when the host
is amd64, even if the specified platform is arm64.

This reverts back to using ARCH, which is derived from PLATFORM. This
means that when linux_arm64 is supplied as platform, we will use arm64
as ARCH, rather than falling back to the host arch. This does not break
local builds for Apple arm64 machines because PLATFORM will be derived
from TARGETARCH since it is not explicitly provided.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

xref https://github.com/upbound/build/pull/139

**NOTE: this issue was identified by examining the image config of images built for `arm64` on an `amd64` host and noticing that the image arch specified was `amd64`.**

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

I am in progress of testing this for multi-platform builds, but I would love for someone with an `arm64` machine to test this out locally as well -- cc @AaronME @tnthornton

Update: I have tested this on a variety of repos by updating the `build` submodule and running `./build/run make -j2 build.all` and validated that the `arm64` images have the correct architecture 👍🏻 