### PR TITLE
Update helm and kubectl

### DIFF
--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -29,7 +29,7 @@ KIND_VERSION ?= v0.11.1
 KIND := $(TOOLS_HOST_DIR)/kind-$(KIND_VERSION)
 
 # the version of kubectl to use
-KUBECTL_VERSION ?= v1.17.11
+KUBECTL_VERSION ?= v1.22.2
 KUBECTL := $(TOOLS_HOST_DIR)/kubectl-$(KUBECTL_VERSION)
 
 # the version of kustomize to use
@@ -42,7 +42,7 @@ OLMBUNDLE := $(TOOLS_HOST_DIR)/olm-bundle-$(OLMBUNDLE_VERSION)
 
 # the version of helm 3 to use
 USE_HELM3 ?= false
-HELM3_VERSION ?= v3.5.3
+HELM3_VERSION ?= v3.7.1
 HELM3 := $(TOOLS_HOST_DIR)/helm-$(HELM3_VERSION)
 
 # If we enable HELM3 we alias HELM to be HELM3
@@ -50,7 +50,7 @@ ifeq ($(USE_HELM3),true)
 HELM_VERSION ?= $(HELM3_VERSION)
 HELM := $(HELM3)
 else
-HELM_VERSION ?= v2.16.7
+HELM_VERSION ?= v2.17.0
 HELM := $(TOOLS_HOST_DIR)/helm-$(HELM_VERSION)
 endif
 


### PR DESCRIPTION
### Description of your changes
- Update kubectl to more a newer version instead of using 1.17 which is deprecated
- also upgrade helm v2 / v3
update helm v2 to the last release which was for security fixes.
update helm v3 to the latest available as today (24.10.2021)



Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

/assign @hasheddan 