### PR TITLE
Add imagelight as alternative image building orchestrator

### DIFF
--- a/makelib/image.mk
+++ b/makelib/image.mk
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# DEPRECATED: this module has been replaced by imagelight.mk and may be removed
+# in the future.
+
 # ====================================================================================
 # Options
 
@@ -259,6 +263,8 @@ endif
 prune: img.prune
 
 define IMAGE_HELPTEXT
+DEPRECATED: this module has been replaced by imagelight.mk and may be removed in the future. 
+
 Image Targets:
     prune        Prune orphaned and cached images.
 

--- a/makelib/imagelight.mk
+++ b/makelib/imagelight.mk
@@ -1,0 +1,214 @@
+# Copyright 2021 The Upbound Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ====================================================================================
+# Options
+
+ifeq ($(origin IMAGE_DIR),undefined)
+IMAGE_DIR := $(ROOT_DIR)/cluster/images
+endif
+
+ifeq ($(origin IMAGE_OUTPUT_DIR),undefined)
+IMAGE_OUTPUT_DIR := $(OUTPUT_DIR)/images/$(PLATFORM)
+endif
+
+ifeq ($(origin IMAGE_TEMP_DIR),undefined)
+IMAGE_TEMP_DIR := $(shell mktemp -d)
+endif
+
+# a registry that is scoped to the current build tree on this host. this enables
+# us to have isolation between concurrent builds on the same system, as in the case
+# of multiple working directories or on a CI system with multiple executors. All images
+# tagged with this build registry can safely be untagged/removed at the end of the build.
+ifeq ($(origin BUILD_REGISTRY), undefined)
+BUILD_REGISTRY := build-$(shell echo $(HOSTNAME)-$(ROOT_DIR) | shasum -a 256 | cut -c1-8)
+endif
+
+# In order to reduce built time especially on jenkins, we maintain a cache
+# of already built images. This cache contains images that can be used to help speed
+# future docker build commands using docker's content addressable schemes.
+# All cached images go in in a 'cache/' local registry and we follow an MRU caching
+# policy -- keeping images that have been referenced around and evicting images
+# that have to been referenced in a while (and according to a policy). Note we can
+# not rely on the image's .CreatedAt date since docker only updates then when the
+# image is created and not referenced. Instead we keep a date in the Tag.
+CACHE_REGISTRY := cache
+
+# prune images that are at least this many hours old
+PRUNE_HOURS ?= 48
+
+# prune keeps at least this many images regardless of how old they are
+PRUNE_KEEP ?= 24
+
+# don't actually prune just show what prune would do.
+PRUNE_DRYRUN ?= 0
+
+# the cached image format
+CACHE_DATE_FORMAT := "%Y-%m-%d.%H%M%S"
+CACHE_PRUNE_DATE := $(shell export TZ="UTC+$(PRUNE_HOURS)"; date +"$(CACHE_DATE_FORMAT)")
+CACHE_TAG := $(shell date -u +"$(CACHE_DATE_FORMAT)")
+
+REGISTRY_ORGS ?= docker.io
+IMAGE_ARCHS := $(subst linux_,,$(filter linux_%,$(PLATFORMS)))
+IMAGE_PLATFORMS := $(subst _,/,$(subst $(SPACE),$(COMMA),$(filter linux_%,$(PLATFORMS))))
+IMAGE_PLATFORMS_LIST := $(subst _,/,$(filter linux_%,$(PLATFORMS)))
+IMAGE_PLATFORM := $(subst _,/,$(PLATFORM))
+
+# if set to 1 docker image caching will not be used.
+CACHEBUST ?= 0
+ifeq ($(CACHEBUST),1)
+BUILD_ARGS += --no-cache
+endif
+
+ifeq ($(HOSTOS),Linux)
+SELF_CID := $(shell cat /proc/self/cgroup | grep docker | grep -o -E '[0-9a-f]{64}' | head -n 1)
+endif
+
+# =====================================================================================
+# Image Targets
+
+do.img.clean:
+	@for i in $(CLEAN_IMAGES); do \
+		if [ -n "$$(docker images -q $$i)" ]; then \
+			for c in $$(docker ps -a -q --no-trunc --filter=ancestor=$$i); do \
+				if [ "$$c" != "$(SELF_CID)" ]; then \
+					echo stopping and removing container $${c} referencing image $$i; \
+					docker stop $${c}; \
+					docker rm $${c}; \
+				fi; \
+			done; \
+			echo cleaning image $$i; \
+			docker rmi $$i > /dev/null 2>&1 || true; \
+		fi; \
+	done
+
+# this will clean everything for this build
+img.clean:
+	@$(INFO) cleaning images for $(BUILD_REGISTRY)
+	@$(MAKE) do.img.clean CLEAN_IMAGES="$(shell docker images | grep -E '^$(BUILD_REGISTRY)/' | awk '{print $$1":"$$2}')"
+	@$(OK) cleaning images for $(BUILD_REGISTRY)
+
+img.done:
+	@rm -fr $(IMAGE_TEMP_DIR)
+
+img.cache:
+	@for i in $(CACHE_IMAGES); do \
+		IMGID=$$(docker images -q $$i); \
+		if [ -n "$$IMGID" ]; then \
+			echo === caching image $$i; \
+			CACHE_IMAGE=$(CACHE_REGISTRY)/$${i#*/}; \
+			docker tag $$i $${CACHE_IMAGE}:$(CACHE_TAG); \
+			for r in $$(docker images --format "{{.ID}}#{{.Repository}}:{{.Tag}}" | grep $$IMGID | grep $(CACHE_REGISTRY)/ | grep -v $${CACHE_IMAGE}:$(CACHE_TAG)); do \
+				docker rmi $${r#*#} > /dev/null 2>&1 || true; \
+			done; \
+		fi; \
+	done
+
+# prune removes old cached images
+img.prune:
+	@$(INFO) pruning images older than $(PRUNE_HOURS) keeping a minimum of $(PRUNE_KEEP) images
+	@EXPIRED=$$(docker images --format "{{.Tag}}#{{.Repository}}:{{.Tag}}" \
+		| grep -E '$(CACHE_REGISTRY)/' \
+		| sort -r \
+		| awk -v i=0 -v cd="$(CACHE_PRUNE_DATE)" -F  "#" '{if ($$1 <= cd && i >= $(PRUNE_KEEP)) print $$2; i++ }') &&\
+	for i in $$EXPIRED; do \
+		echo removing expired cache image $$i; \
+		[ $(PRUNE_DRYRUN) = 1 ] || docker rmi $$i > /dev/null 2>&1 || true; \
+	done
+	@for i in $$(docker images -q -f dangling=true); do \
+		echo removing dangling image $$i; \
+		docker rmi $$i > /dev/null 2>&1 || true; \
+	done
+	@$(OK) pruning
+
+debug.nuke:
+	@for c in $$(docker ps -a -q --no-trunc); do \
+		if [ "$$c" != "$(SELF_CID)" ]; then \
+			echo stopping and removing container $${c}; \
+			docker stop $${c}; \
+			docker rm $${c}; \
+		fi; \
+	done
+	@for i in $$(docker images -q); do \
+		echo removing image $$i; \
+		docker rmi -f $$i > /dev/null 2>&1; \
+	done
+
+# 1: registry 2: image
+define repo.targets
+img.release.publish.$(1).$(2):
+	@$(MAKE) -C $(IMAGE_DIR)/$(2) IMAGE_PLATFORMS=$(IMAGE_PLATFORMS) IMAGE=$(1)/$(2):$(VERSION) img.publish
+img.release.publish: img.release.publish.$(1).$(2)
+
+img.release.promote.$(1).$(2):
+	@$(MAKE) -C $(IMAGE_DIR)/$(2) TO_IMAGE=$(1)/$(2):$(CHANNEL) FROM_IMAGE=$(1)/$(2):$(VERSION) img.promote
+	@[ "$(CHANNEL)" = "master" ] || @$(MAKE) -C $(IMAGE_DIR)/$(2) TO_IMAGE=$(1)/$(2):$(VERSION)-$(CHANNEL) FROM_IMAGE=$(1)/$(2):$(VERSION) img.promote
+img.release.promote: img.release.promote.$(1).$(2)
+
+img.release.clean.$(1).$(2):
+	@[ -z "$$$$(docker images -q $(1)/$(2):$(VERSION))" ] || docker rmi $(1)/$(2):$(VERSION)
+	@[ -z "$$$$(docker images -q $(1)/$(2):$(VERSION)-$(CHANNEL))" ] || docker rmi $(1)/$(2):$(VERSION)-$(CHANNEL)
+	@[ -z "$$$$(docker images -q $(1)/$(2):$(CHANNEL))" ] || docker rmi $(1)/$(2):$(CHANNEL)
+img.release.clean: img.release.clean.$(1).$(2)
+endef
+$(foreach r,$(REGISTRY_ORGS), $(foreach i,$(IMAGES),$(eval $(call repo.targets,$(r),$(i)))))
+
+# ====================================================================================
+# Common Targets
+
+do.build.image.%:
+	@$(MAKE) -C $(IMAGE_DIR)/$* IMAGE_PLATFORMS=$(IMAGE_PLATFORM) IMAGE=$(BUILD_REGISTRY)/$*-$(ARCH) img.build
+do.build.images: $(foreach i,$(IMAGES), do.build.image.$(i))
+do.skip.images:
+	@$(OK) Skipping image build for unsupported platform $(IMAGE_PLATFORM)
+
+ifneq ($(filter $(IMAGE_PLATFORM),$(IMAGE_PLATFORMS_LIST)),)
+build.artifacts.platform: do.build.images
+else
+build.artifacts.platform: do.skip.images
+endif
+build.done: img.cache img.done
+clean: img.clean img.release.clean
+
+# only publish images for main / master and release branches
+# TODO(hasheddan): remove master and support overriding
+ifneq ($(filter main master release-%,$(BRANCH_NAME)),)
+publish.artifacts: $(foreach r,$(REGISTRY_ORGS), $(foreach i,$(IMAGES),img.release.publish.$(r).$(i)))
+endif
+
+promote.artifacts: $(foreach r,$(REGISTRY_ORGS), $(foreach i,$(IMAGES),img.release.promote.$(r).$(i)))
+
+# ====================================================================================
+# Special Targets
+
+prune: img.prune
+
+define IMAGE_HELPTEXT
+Image Targets:
+    prune        Prune orphaned and cached images.
+
+Image Options:
+    PRUNE_HOURS  The number of hours from when an image is last used for it to be
+                 considered a target for pruning. Default is 48 hrs.
+    PRUNE_KEEP   The minimum number of cached images to keep. Default is 24 images.
+
+endef
+export IMAGE_HELPTEXT
+
+img.help:
+	@echo "$$IMAGE_HELPTEXT"
+
+help-special: img.help
+
+.PHONY: prune img.help

--- a/makelib/imagelight.mk
+++ b/makelib/imagelight.mk
@@ -153,7 +153,7 @@ img.release.publish: img.release.publish.$(1).$(2)
 
 img.release.promote.$(1).$(2):
 	@$(MAKE) -C $(IMAGE_DIR)/$(2) TO_IMAGE=$(1)/$(2):$(CHANNEL) FROM_IMAGE=$(1)/$(2):$(VERSION) img.promote
-	@[ "$(CHANNEL)" = "master" ] || @$(MAKE) -C $(IMAGE_DIR)/$(2) TO_IMAGE=$(1)/$(2):$(VERSION)-$(CHANNEL) FROM_IMAGE=$(1)/$(2):$(VERSION) img.promote
+	@[ "$(CHANNEL)" = "master" ] || $(MAKE) -C $(IMAGE_DIR)/$(2) TO_IMAGE=$(1)/$(2):$(VERSION)-$(CHANNEL) FROM_IMAGE=$(1)/$(2):$(VERSION) img.promote
 img.release.promote: img.release.promote.$(1).$(2)
 
 img.release.clean.$(1).$(2):


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds a new image building orchestration Makefile that is mutually
exclusive with image.mk. The purpose of imagelight.mk is to defer more
of the functionality to the individual image makefiles that exist in a
repo that consumes the build submodule. This use case has become more
desirable as we move towards tools such as buildx, but imagelight does
not specifically constrain the consumer to any one image building tool.

There are a few notable differences from image.mk, including but not
limited to:
- We do not save images as tarballs to an output directory, though
individual image makefiles in a repo could opt to do so on their own.
- We support publishing to multiple registries and repositories. An
arbitrary number of REGISTRY_ORGS can be defined in the top-level
Makefile in a repo, and each image defined in that repository will be
published to every specified location in REGISTRY_ORGS. REGISTRY_ORGS
take the format of registry-name/org-name (e.g. docker.io/crossplane).
- We skip building for platforms that are not valid, which, for now,
excludes all non-linux platforms. This simplifies the process of
specifying platforms in a repository because we do not force the
consumer to override platforms for which they want to build binaries but
do not want to or cannot publish images.
- We do not call common.mk targets when invoking the image-specific
Makefiles in a repository. This is an unnecessary level of indirection
that doesn't provide much additional value in any of the repos that
consume the build submodule. We instead call the targets in the image
Makefiles directly, requiring img.build, img.publish, and img.promote to
be defined.

Note that image.mk remain unmodified, which allows for any repositories
that currently consume it to continue doing so. I do not anticipate
removing image.mk any time soon as it provides different functionality
than imagelight.mk and some projects may opt never to switch.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

I have tested this functionality fairly extensively with building / publishing / promoting images in `crossplane/crossplane`. I will also open a PR there to demonstrate this functionality, and will link it here. For reference, here is an example image Makefile that opts to use `docker buildx` for image operations.

```
# ====================================================================================
# Setup Project

include ../../../build/makelib/common.mk

# ====================================================================================
#  Options

include ../../../build/makelib/imagelight.mk

# ====================================================================================
# Targets

img.build:
	@$(INFO) docker build $(IMAGE)
	@$(MAKE) BUILD_ARGS="--load" img.build.shared
	@$(OK) docker build $(IMAGE)

img.publish:
	@$(INFO) docker publish $(IMAGE)
	@$(MAKE) BUILD_ARGS="--push" img.build.shared
	@$(OK) docker publish $(IMAGE)

img.build.shared:
	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
	@cp -r $(OUTPUT_DIR)/bin/ $(IMAGE_TEMP_DIR)/bin || $(FAIL)
	@cp -a ../../../cluster/crds $(IMAGE_TEMP_DIR) || $(FAIL)
	@docker buildx build $(BUILD_ARGS) \
		--platform $(IMAGE_PLATFORMS) \
		-t $(IMAGE) \
		$(IMAGE_TEMP_DIR) || $(FAIL)

img.promote:
	@$(INFO) docker promote $(FROM_IMAGE) to $(TO_IMAGE)
	@docker buildx imagetools create -t $(TO_IMAGE) $(FROM_IMAGE)
	@$(OK) docker promote $(FROM_IMAGE) to $(TO_IMAGE)
``` 
