### PR TITLE
Remove img.cache as build.done prereq

### DIFF
--- a/makelib/imagelight.mk
+++ b/makelib/imagelight.mk
@@ -111,7 +111,7 @@ build.artifacts.platform: do.build.images
 else
 build.artifacts.platform: do.skip.images
 endif
-build.done: img.cache img.done
+build.done: img.done
 clean: img.clean img.release.clean
 
 # only publish images for main / master and release branches


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Removes the non-existent img.cache target as a prereq to build.done.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Tested with https://github.com/crossplane/crossplane/pull/2718 (which is currently failing because of this).