### PR TITLE
Fixing an issue where basename is called with branch included

### DIFF
--- a/scripts/localdev-prepare.sh
+++ b/scripts/localdev-prepare.sh
@@ -57,8 +57,12 @@ if [ -n "${LOCAL_DEV_REPOS}" ]; then
   repositories_arr=($LOCAL_DEV_REPOS)
   for i in ${repositories_arr[@]+"${repositories_arr[@]}"}; do
 
+    IFS='@' read -ra repo_and_branch <<< "${i}"
+    repo="${repo_and_branch[0]}"
+    branch="${repo_and_branch[1]:-}"
+
     local_repo=$(basename $(git config --get remote.origin.url) .git)
-    base_repo=$(basename "${i}" .git)
+    base_repo=$(basename "${repo}" .git)
 
     if [ "${LOCALDEV_LOCAL_BUILD}" == "true" ] && [ "${base_repo}" == "${local_repo}" ]; then
       # if it is a local build and repo is the local one, just use local config


### PR DESCRIPTION
### Description of your changes

While testing a branch fix for local-dev I encountered the error:
```bash
No local dev config found for repo "<repo>@<branch>"
```

Because we enable targeting branches of repos, we need to clean the repo_name when preparing our local-dev configs.

Fixes #

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [N/A] Run `make reviewable` to ensure this PR is ready for review.
- [N/A] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Tested in a local build.