### PR TITLE
Add `up` download machinery

### DIFF
--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -65,6 +65,8 @@ k8s_tools.buildvars:
 	@echo KIND=$(KIND)
 	@echo KUBECTL=$(KUBECTL)
 	@echo KUSTOMIZE=$(KUSTOMIZE)
+	@echo OLM_BUNDLE=$(OLM_BUNDLE)
+	@echo UP=$(UP)
 	@echo HELM=$(HELM)
 	@echo HELM3=$(HELM3)
 

--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -40,6 +40,10 @@ KUSTOMIZE := $(TOOLS_HOST_DIR)/kustomize-$(KUSTOMIZE_VERSION)
 OLMBUNDLE_VERSION ?= v0.4.0
 OLMBUNDLE := $(TOOLS_HOST_DIR)/olm-bundle-$(OLMBUNDLE_VERSION)
 
+# the version of up to use
+UP_VERSION ?= v0.10.0
+UP := $(TOOLS_HOST_DIR)/up-$(UP_VERSION)
+
 # the version of helm 3 to use
 USE_HELM3 ?= false
 HELM3_VERSION ?= v3.7.1
@@ -108,6 +112,13 @@ $(OLMBUNDLE):
 	@curl -fsSLo $(OLMBUNDLE) https://github.com/upbound/olm-bundle/releases/download/$(OLMBUNDLE_VERSION)/olm-bundle_$(SAFEHOSTPLATFORM) || $(FAIL)
 	@chmod +x $(OLMBUNDLE)
 	@$(OK) installing olm-bundle $(OLMBUNDLE_VERSION)
+
+# up download and install
+$(UP):
+	@$(INFO) installing up $(UP_VERSION)
+	@curl -fsSLo $(UP) https://cli.upbound.io/stable/$(UP_VERSION)/bin/$(SAFEHOST_PLATFORM)/up?source=build || $(FAIL)
+	@chmod +x $(UP)
+	@$(OK) installing up $(UP_VERSION)
 
 # helm download and install only if helm3 not enabled
 ifeq ($(USE_HELM3),false)


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds machinery to download and install up in the tools directory.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Tested with `provider-aws` using the following path on the integration tests:

```
diff --git a/cluster/local/integration_tests.sh b/cluster/local/integration_tests.sh
index 6077c5bd..04b12748 100755
--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -42,6 +42,7 @@ eval $(make --no-print-directory -C ${projectdir} build.vars)
 
 SAFEHOSTARCH="${SAFEHOSTARCH:-amd64}"
 BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${SAFEHOSTARCH}"
+PACKAGE_IMAGE="crossplane.io/inttests/${PROJECT_NAME}:${VERSION}"
 CONTROLLER_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-controller-${SAFEHOSTARCH}"
 
 version_tag="$(cat ${projectdir}/_output/version)"
@@ -68,7 +69,9 @@ echo_step "setting up local package cache"
 CACHE_PATH="${projectdir}/.work/inttest-package-cache"
 mkdir -p "${CACHE_PATH}"
 echo "created cache dir at ${CACHE_PATH}"
-docker save "${BUILD_IMAGE}" -o "${CACHE_PATH}/${PACKAGE_NAME}.xpkg" && chmod 644 "${CACHE_PATH}/${PACKAGE_NAME}.xpkg"
+docker tag "${BUILD_IMAGE}" "${PACKAGE_IMAGE}"
+"${UP}" --version
+"${UP}" xpkg xp-extract --from-daemon "${PACKAGE_IMAGE}" -o "${CACHE_PATH}/${PACKAGE_NAME}.gz" && chmod 644 "${CACHE_PATH}/${PACKAGE_NAME}.gz"
 
 # create kind cluster with extra mounts
 KIND_NODE_IMAGE="kindest/node:${KIND_NODE_IMAGE_TAG}"
@@ -92,7 +95,7 @@ docker tag "${CONTROLLER_IMAGE}" "${PACKAGE_CONTROLLER_IMAGE}"
 # files are not synced properly from host to kind node container on Jenkins, so
 # we must manually copy image from host to node
 echo_step "pre-cache package by copying to kind node"
-docker cp "${CACHE_PATH}/${PACKAGE_NAME}.xpkg" "${K8S_CLUSTER}-control-plane":"/cache/${PACKAGE_NAME}.xpkg"
+docker cp "${CACHE_PATH}/${PACKAGE_NAME}.gz" "${K8S_CLUSTER}-control-plane":"/cache/${PACKAGE_NAME}.gz"
 
 echo_step "create crossplane-system namespace"
 "${KUBECTL}" create ns crossplane-system
```

And verified that tests run successfully with Crossplane `v1.7.0`:

```
>>>>>>> --- INTEGRATION TESTS ---

>>>>>>> installing provider-aws into "crossplane-system" namespace
provider.pkg.crossplane.io/provider-aws created

>>>>>>> check kind node cache dir contents
total 408
drwxrwxr-x 2 1000 1000   4096 Mar 30 02:48 .
drwxr-xr-x 1 root root   4096 Mar 30 02:48 ..
-rw-r--r-- 1 1000 1000 406797 Mar 30 02:47 provider-aws.gz

>>>>>>> waiting for provider to be installed
provider.pkg.crossplane.io/provider-aws condition met

>>>>>>> uninstalling provider-aws
provider.pkg.crossplane.io "provider-aws" deleted
waiting for provider to be deleted for another 3 seconds
waiting for provider to be deleted for another 3 seconds

Integration tests succeeded!

>>>>>>> Cleaning up...
Deleting cluster "build-b3b12a66-inttests" ...
22:49:13 [ OK ] integration tests passed
```