### PR TITLE
Replace darwin with linux when building images using buildx

### DIFF
--- a/makelib/imagelight.mk
+++ b/makelib/imagelight.mk
@@ -27,6 +27,9 @@ ifeq ($(origin IMAGE_TEMP_DIR),undefined)
 IMAGE_TEMP_DIR := $(shell mktemp -d)
 endif
 
+# we don't support darwin os images and instead strictly target linux
+PLATFORM := $(subst darwin,linux,$(PLATFORM))
+
 # a registry that is scoped to the current build tree on this host. this enables
 # us to have isolation between concurrent builds on the same system, as in the case
 # of multiple working directories or on a CI system with multiple executors. All images


### PR DESCRIPTION
### Description of your changes
When using a Darwin OS and imagelight.mk, `img.build` targets are being fed `IMAGE_PLATFORMS=darwin_${HOSTARCH}`. However, this is generally invalid for the images that are published/consumed by upbound and crossplane. This change substitutes `linux` for `darwin` in the event this is seen while attempting to build the images.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).

### How has this code been tested
Tested this behavior on a consuming repo. With this change, attempts to build an image have the appropriate `IMAGE_PLATFORMS` being fed to the docker command.

Before:
```bash
14:57:09 [ .. ] docker build build-1e336c54/shimmer-sql-arm64
docker buildx build --load \
		--platform darwin/arm64 \
		-t build-1e336c54/shimmer-sql-arm64 \
		/var/folders/qh/kb2fj2915zn36r801mw29q_00000gn/T/tmp.3okr3pfr || (echo `date +%H:%M:%S` [FAIL] && false)
```
After:
```bash
docker buildx build --load \
		--platform linux/arm64 \
		-t build-1e336c54/shimmer-sql-arm64 \
		/var/folders/qh/kb2fj2915zn36r801mw29q_00000gn/T/tmp.VedLW0Db || (echo `date +%H:%M:%S` [FAIL] && false)```
