### PR TITLE
common: add ability to provide glob to match tags during version

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -213,7 +213,9 @@ ifeq ($(shell git tag),)
 VERSION := $(shell echo "v0.0.0-$$(git rev-list HEAD --count)-g$$(git describe --dirty --always)" | sed 's/-/./2' | sed 's/-/./2' | sed 's/-/./2')
 else
 # use tags
-VERSION := $(shell git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' | sed 's/-/./2' )
+# set if you want to consider only the tags matching your glob, e.g. "aws/*".
+VERSION_TAG_MATCH ?= '*'
+VERSION := $(shell git describe --dirty --always --tags --match '$(VERSION_TAG_MATCH)' | sed 's|.*/||' | sed 's/-/./2' | sed 's/-/./2' | sed 's/-/./2')
 endif
 endif
 export VERSION


### PR DESCRIPTION
### Description of your changes

Needed in mono repos where there might be tags that are put in place by other projects in the same repo. This allows each project to specify a glob to match.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Projects could opt in to use the new `PROJECT_VERSION_TAG_GROUP`. The following are the scenarios I tried to make sure the ones that do not opt it are not affected and the ones that do get the expected behavior, that is tagging with `prefix/v0.0.0` and release branch named `release-prefix-0.1`.

I commented out all `git` commands under `releases.tag` target to make sure it doesn't affect the real repos but still print the command and added a target `make vers` temporarily to see what's calculated as `VERSION`:
```
vers:
	@(INFO) version is $(VERSION)
```

I tried the same scenarios in `crossplane/crossplane` as well to make sure `VERSION` calculation is not impacted.

#### No `PROJECT_VERSION_TAG_GROUP`

With no change in `Makefile` of the project, I ran the following to validate `make tag` behavior doesn't change:
```
$ make tag VERSION=v0.1.0
18:43:32 [ .. ] tagging commit hash 398e02c374738243dc296b182eb9d07b7f3438ed with v0.1.0
#git tag -f -m "v0.1.0" v0.1.0 398e02c374738243dc296b182eb9d07b7f3438ed
#git push origin v0.1.0
=== creating new release branch release-0.1
18:43:34 [ OK ] tagging
make vers
18:50:22 [ .. ] version is v0.0.0-82.g398e02c.dirty
```


#### `PROJECT_VERSION_TAG_GROUP` defined

```
$ make tag VERSION=v0.1.0
18:44:10 [ .. ] tagging commit hash 398e02c374738243dc296b182eb9d07b7f3438ed with azure/v0.1.0
#git tag -f -m "azure/v0.1.0" azure/v0.1.0 398e02c374738243dc296b182eb9d07b7f3438ed
#git push origin azure/v0.1.0
=== creating new release branch release-azure-0.1
18:44:12 [ OK ] tagging
```

```
$ make vers
18:48:22 [ .. ] version is v0.0.0-82.g398e02c.dirty
```

#### `PROJECT_VERSION_TAG_GROUP` defined and two commits tagged with different tag groups

One commit is tagged with `aws/v0.1.0` and the next one with `azure/v0.2.0` and the value for `PROJECT_VERSION_TAG_GROUP` is `azure`.
```
$ make vers
18:54:13 [ .. ] version is v0.2.0-4.g398e02c.dirty
```

The value is changed to `aws`:
```
$ make vers
18:54:48 [ .. ] version is v0.1.0-3.g398e02c.dirty
```