### PR TITLE
Use /usr/bin/env to find bash

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -16,7 +16,7 @@
 .SUFFIXES:
 
 # set the shell to bash always
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 # default target is build
 .PHONY: all


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

In some rare cases (e.g. on NixOS) bash is not at /bin/bash. Using env to find where the shell actually is is a fairly common pattern per https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability. It's also possible that /usr/bin/env is not at that path, but anecodally the internet considers it to be "more likely" to be there than /bin/bash, which is not the standard path on most BSDs and some rare Linux variants.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

I've made the edit locally and run `make reviewable` against https://github.com/crossplane/crossplane.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
