### PR TITLE
fix: Fallback to sha256sum if shasum is not available

### DIFF
--- a/makelib/image.mk
+++ b/makelib/image.mk
@@ -44,12 +44,19 @@ $(error unsupported architecture $(ARCH))
 endif
 endif
 
+# shasum is not available on all systems. In that case, fall back to sha256sum.
+ifneq ($(shell type shasum 2>/dev/null),)
+SHA256SUM := shasum -a 256
+else
+SHA256SUM := sha256sum
+endif
+
 # a registry that is scoped to the current build tree on this host. this enables
 # us to have isolation between concurrent builds on the same system, as in the case
 # of multiple working directories or on a CI system with multiple executors. All images
 # tagged with this build registry can safely be untagged/removed at the end of the build.
 ifeq ($(origin BUILD_REGISTRY), undefined)
-BUILD_REGISTRY := build-$(shell echo $(HOSTNAME)-$(ROOT_DIR) | shasum -a 256 | cut -c1-8)
+BUILD_REGISTRY := build-$(shell echo $(HOSTNAME)-$(ROOT_DIR) | $(SHA256SUM) | cut -c1-8)
 endif
 
 MANIFEST_TOOL_VERSION=v1.0.3

--- a/makelib/imagelight.mk
+++ b/makelib/imagelight.mk
@@ -30,12 +30,19 @@ endif
 # we don't support darwin os images and instead strictly target linux
 PLATFORM := $(subst darwin,linux,$(PLATFORM))
 
+# shasum is not available on all systems. In that case, fall back to sha256sum.
+ifneq ($(shell type shasum 2>/dev/null),)
+SHA256SUM := shasum -a 256
+else
+SHA256SUM := sha256sum
+endif
+
 # a registry that is scoped to the current build tree on this host. this enables
 # us to have isolation between concurrent builds on the same system, as in the case
 # of multiple working directories or on a CI system with multiple executors. All images
 # tagged with this build registry can safely be untagged/removed at the end of the build.
 ifeq ($(origin BUILD_REGISTRY), undefined)
-BUILD_REGISTRY := build-$(shell echo $(HOSTNAME)-$(ROOT_DIR) | shasum -a 256 | cut -c1-8)
+BUILD_REGISTRY := build-$(shell echo $(HOSTNAME)-$(ROOT_DIR) | $(SHA256SUM) | cut -c1-8)
 endif
 
 REGISTRY_ORGS ?= docker.io


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

This adds a fallback to `sha256sum` if `shasum` is not available.

Fixes #191 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Manually on Fedora 36.
