### PR TITLE
Stop hardcoding `SAFEHOSTARCH` to `amd64` on darwin

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -105,13 +105,6 @@ endif
 # Set the host's arch.
 HOSTARCH := $(shell uname -m)
 
-# Set safe architectures for supported OSes (darwin and linux).
-# Apple Silicon binaries are not widely available yet
-ifeq ($(HOSTOS),darwin)
-SAFEHOSTARCH := amd64
-TARGETARCH := $(HOSTARCH)
-endif
-
 # If SAFEHOSTARCH and TARGETARCH have not been defined yet, use HOST
 ifeq ($(origin SAFEHOSTARCH),undefined)
 SAFEHOSTARCH := $(HOSTARCH)
@@ -211,7 +204,7 @@ endif
 # ====================================================================================
 # Version and Tagging
 
-# set if you want to use tag grouping, e.g. setting it to "aws" would produce tags like "aws/v0.1.0" 
+# set if you want to use tag grouping, e.g. setting it to "aws" would produce tags like "aws/v0.1.0"
 # and release branch would be named as "release-aws-0.1" but the version would still be "v0.1.0".
 ifneq ($(PROJECT_VERSION_TAG_GROUP),)
 VERSION_TAG_PREFIX := $(PROJECT_VERSION_TAG_GROUP)/
@@ -490,4 +483,3 @@ help:
 	@$(MAKE) help-special
 
 .PHONY: help help-special
-

--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -16,12 +16,12 @@
 # Options
 
 # the version of istio to use
-ISTIO_VERSION ?= 1.8.1
+ISTIO_VERSION ?= 1.12.9
 ISTIO := $(TOOLS_HOST_DIR)/istioctl-$(ISTIO_VERSION)
 ISTIOOS := $(HOSTOS)
 ISTIO_DOWNLOAD_TUPLE := $(SAFEHOSTPLATFORM)
 ifeq ($(HOSTOS),darwin)
-ISTIO_DOWNLOAD_TUPLE := osx
+ISTIO_DOWNLOAD_TUPLE := osx-$(SAFEHOSTARCH)
 endif
 
 # the version of kind to use
@@ -29,15 +29,15 @@ KIND_VERSION ?= v0.14.0
 KIND := $(TOOLS_HOST_DIR)/kind-$(KIND_VERSION)
 
 # the version of kubectl to use
-KUBECTL_VERSION ?= v1.24.1
+KUBECTL_VERSION ?= v1.24.3
 KUBECTL := $(TOOLS_HOST_DIR)/kubectl-$(KUBECTL_VERSION)
 
 # the version of kustomize to use
-KUSTOMIZE_VERSION ?= v3.3.0
+KUSTOMIZE_VERSION ?= v4.5.5
 KUSTOMIZE := $(TOOLS_HOST_DIR)/kustomize-$(KUSTOMIZE_VERSION)
 
 # the version of olm-bundle to use
-OLMBUNDLE_VERSION ?= v0.4.0
+OLMBUNDLE_VERSION ?= v0.5.2
 OLMBUNDLE := $(TOOLS_HOST_DIR)/olm-bundle-$(OLMBUNDLE_VERSION)
 
 # the version of up to use
@@ -47,7 +47,7 @@ UP := $(TOOLS_HOST_DIR)/up-$(UP_VERSION)
 
 # the version of helm 3 to use
 USE_HELM3 ?= false
-HELM3_VERSION ?= v3.7.1
+HELM3_VERSION ?= v3.9.1
 HELM3 := $(TOOLS_HOST_DIR)/helm-$(HELM3_VERSION)
 
 # If we enable HELM3 we alias HELM to be HELM3


### PR DESCRIPTION
Signed-off-by: Aditya Sharma <git@adi.run>

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Stop hardcoding `SAFEHOSTARCH` to `amd64` on darwin.

Running make on `github.com/upbound/xgql` with these changes fetches the correct helm binaries:
```
lipo -detailed_info /Users/adi/src/github.com/upbound/xgql/.cache/tools/darwin_arm64/helm-v3.7.1
input file /Users/adi/src/github.com/upbound/xgql/.cache/tools/darwin_arm64/helm-v3.7.1 is not a fat file
Non-fat file: /Users/adi/src/github.com/upbound/xgql/.cache/tools/darwin_arm64/helm-v3.7.1 is architecture: arm64
```

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
