### PR TITLE
Update `golangci-lint` to `1.47.1`

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -96,7 +96,7 @@ endif
 
 # We use a consistent version of golangci-lint to ensure everyone gets the same
 # linters.
-GOLANGCILINT_VERSION ?= 1.31.0
+GOLANGCILINT_VERSION ?= 1.47.1
 GOLANGCILINT := $(TOOLS_HOST_DIR)/golangci-lint-v$(GOLANGCILINT_VERSION)
 
 GO_BIN_DIR := $(abspath $(OUTPUT_DIR)/bin)
@@ -259,7 +259,7 @@ endif
 go.clean:
 	@# `go modules` creates read-only folders under WORK_DIR
 	@# make all folders within WORK_DIR writable, so they can be deleted
-	@if [ -d $(WORK_DIR) ]; then chmod -R +w $(WORK_DIR); fi 
+	@if [ -d $(WORK_DIR) ]; then chmod -R +w $(WORK_DIR); fi
 
 	@rm -fr $(GO_BIN_DIR) $(GO_TEST_DIR)
 


### PR DESCRIPTION
Signed-off-by: Aditya Sharma <git@adi.run>

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Update `golangci-lint` to `1.47.1` to be able to install `darwin_arm64` binaries

#### Before
```
✨  Done in 0.31s.
10:05:52 [ .. ] verify dependencies have expected content
all modules verified
10:05:54 [ OK ] go modules dependencies verified
10:05:54 [ .. ] installing golangci-lint-v1.31.0 darwin-arm64
curl: (22) The requested URL returned error: 404
mv: rename /Users/adi/src/github.com/upbound/xgql/.cache/tools/darwin_arm64/tmp-golangci-lint/golangci-lint to /Users/adi/src/github.com/upbound/xgql/.cache/tools/darwin_arm64/golangci-lint-v1.31.0: No such file or directory
10:05:54 [FAIL]
make[1]: *** [/Users/adi/src/github.com/upbound/xgql/.cache/tools/darwin_arm64/golangci-lint-v1.31.0] Error 1
make: *** [lint] Error 2
```

#### After

```
✨  Done in 0.31s.
10:23:08 [ .. ] verify dependencies have expected content
all modules verified
10:23:09 [ OK ] go modules dependencies verified
10:23:09 [ .. ] installing golangci-lint-v1.47.1 darwin-arm64
10:23:11 [ OK ] installing golangci-lint-v1.47.1 darwin-arm64
10:23:11 [ .. ] golangci-lint
WARN [runner] The linter 'scopelint' is deprecated (since v1.39.0) due to: The repository of the linter has been deprecated by the owner.  Replaced by exportloopref.
WARN [runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.
WARN [linters context] bodyclose is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] contextcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] interfacer is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] nilerr is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] noctx is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] rowserrcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] sqlclosecheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
10:23:36 [ OK ] golangci-lint
```
I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
