### PR TITLE
Istio and helm v2 should not be a requirement for local dev

### DIFF
--- a/makelib/local.mk
+++ b/makelib/local.mk
@@ -135,13 +135,13 @@ endif
 
 local.down: kind.down local.clean
 
-local.deploy.%: local.prepare $(KUBECTL) $(KUSTOMIZE) $(HELM) $(HELM3) $(HELM_HOME) $(GOMPLATE) $(ISTIO) kind.setcontext
+local.deploy.%: local.prepare $(KUBECTL) $(KUSTOMIZE) $(HELM3) $(HELM_HOME) $(GOMPLATE) kind.setcontext
 	@$(INFO) localdev deploy component: $*
 	@$(eval PLATFORMS=$(BUILD_PLATFORMS))
 	@$(SCRIPTS_DIR)/localdev-deploy-component.sh $* || $(FAIL)
 	@$(OK) localdev deploy component: $*
 
-local.remove.%: local.prepare $(KUBECTL) $(HELM) $(HELM3) $(HELM_HOME) $(GOMPLATE) kind.setcontext
+local.remove.%: local.prepare $(KUBECTL) $(HELM3) $(HELM_HOME) $(GOMPLATE) kind.setcontext
 	@$(INFO) localdev remove component: $*
 	@$(SCRIPTS_DIR)/localdev-remove-component.sh $* || $(FAIL)
 	@$(OK) localdev remove component: $*


### PR DESCRIPTION
### Description of your changes

This PR removes installing istio client and helm v2 with local dev setup.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

By running local dev in a depending repo.
