### PR TITLE
go.modules.tidy.check: fix `bash: go.mod: command not found`

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -223,7 +223,7 @@ go.modules.tidy:
 go.modules.tidy.check:
 	@$(INFO) verify go modules dependencies are tidy
 	@$(GO) mod tidy
-	@$(shell git diff --exit-code --name-only go.mod go.sum)
+	@changed=$$(git diff --exit-code --name-only go.mod go.sum 2>&1) && [ -z "$${changed}" ] || (echo "go.mod is not tidy" 1>&2; $(FAIL))
 	@$(OK) go modules are tidy
 
 go.modules.update:


### PR DESCRIPTION
Signed-off-by: Aditya Sharma <git@adi.run>

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes `bash: go.mod: command not found`

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

- Checkout this branch
- Run `make go.modules.tidy.check` with a dirty go.mod/go.sum 
- Should output `go.mod is not tidy` instead of `bash: go.mod: command not found`