### PR TITLE
Remove go.distclean in makelib/golang.mk based on #196

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -259,7 +259,6 @@ go.generate:
 build.init: go.init
 build.code.platform: go.build
 clean: go.clean
-distclean: go.distclean
 lint.init: go.init
 lint.run: go.lint
 test.init: go.init


### PR DESCRIPTION
### Description of your changes

Here is the error message when doing `make distclean` 
```bash
make: *** No rule to make target `go.distclean', needed by `distclean'.  Stop.
```

After I browsing the changes #196 and confirmed that the `go.distclean` no longer needed. 

Fixes a missing piece in #196 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
Simply test it with `make distclean` to see if the error message still there. 