### PR TITLE
fix:(helm): Set HELM_*_HOME env vars to avoid side effects with go

### DIFF
--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -46,12 +46,12 @@ export HELM_HOME
 
 # https://helm.sh/docs/faq/#xdg-base-directory-support
 ifeq ($(USE_HELM3),true)
-XDG_DATA_HOME := $(HELM_HOME)
-XDG_CONFIG_HOME := $(HELM_HOME)
-XDG_CACHE_HOME := $(HELM_HOME)
-export XDG_DATA_HOME
-export XDG_CONFIG_HOME
-export XDG_CACHE_HOME
+HELM_CACHE_HOME = $(HELM_HOME)/cache
+HELM_CONFIG_HOME = $(HELM_HOME)/config
+HELM_DATA_HOME = $(HELM_HOME)/data
+export HELM_CACHE_HOME
+export HELM_CONFIG_HOME
+export HELM_DATA_HOME
 endif
 
 # remove the leading `v` for helm chart versions
@@ -117,6 +117,9 @@ helm.build: $(HELM_INDEX)
 
 helm.clean:
 	@rm -fr $(HELM_OUTPUT_DIR)
+
+helm.env: $(HELM)
+	@$(HELM) env
 
 # ====================================================================================
 # helm


### PR DESCRIPTION
### Description of your changes

This removes exports of the `XDG_*` environment variables and exports `HELM_*_HOME` instead which has the same effect in Helm but avoids the side effects with Go that causes `GOCACHE` to be set to `.work/go-build`.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manually
