### PR TITLE
Bump up GOLANGCILINT_VERSION to support build with go 1.19

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -104,7 +104,7 @@ endif
 
 # We use a consistent version of golangci-lint to ensure everyone gets the same
 # linters.
-GOLANGCILINT_VERSION ?= 1.47.1
+GOLANGCILINT_VERSION ?= 1.49.0
 GOLANGCILINT := $(TOOLS_HOST_DIR)/golangci-lint-v$(GOLANGCILINT_VERSION)
 
 GO_BIN_DIR := $(abspath $(OUTPUT_DIR)/bin)

--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -104,7 +104,7 @@ endif
 
 # We use a consistent version of golangci-lint to ensure everyone gets the same
 # linters.
-GOLANGCILINT_VERSION ?= 1.49.0
+GOLANGCILINT_VERSION ?= 1.50.1
 GOLANGCILINT := $(TOOLS_HOST_DIR)/golangci-lint-v$(GOLANGCILINT_VERSION)
 
 GO_BIN_DIR := $(abspath $(OUTPUT_DIR)/bin)


### PR DESCRIPTION
Signed-off-by: Chuan-Yen Chiang <cychiang0823@gmail.com>

### Description of your changes
In this PR, I bump up the `golangcilint` version from `1.47.1` to `1.49.0` to support build with go version higher than 1.17.

It would be really helpful to merge this change because all `crossplane` related projects are using the same build project, like `provider-template`, `crossplane` and `crossplane-runtime`. 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
I tested this change in `provider-template` project with the following go version: 
* `1.17`
* `1.18`
* `1.19`

All above go versions are able to pass the `make reviewable` command. Before that, the command only compatible with `1.17` and show the following message when using `1.18` and `1.19`
```
...
failed to load package goarch: could not load export data: cannot import "internal/goarch"
```
