### PR TITLE
Pass controller flag only for provider packages

### DIFF
--- a/makelib/xpkg.mk
+++ b/makelib/xpkg.mk
@@ -64,8 +64,9 @@ define xpkg.build.targets
 xpkg.build.$(1):
 	@$(INFO) Building package $(1)-$(VERSION).xpkg for $(PLATFORM)
 	@mkdir -p $(OUTPUT_DIR)/xpkg/$(PLATFORM)
-	@$(UP) xpkg build \
-		--controller $(BUILD_REGISTRY)/$(1)-$(ARCH) \
+	@controller_arg=$$$$(grep -E '^kind:\s+Provider\s*$$$$' $(XPKG_DIR)/crossplane.yaml > /dev/null && echo "--controller $(BUILD_REGISTRY)/$(1)-$(ARCH)"); \
+	$(UP) xpkg build \
+		$$$${controller_arg} \
 		--package-root $(XPKG_DIR) \
 		--examples-root $(XPKG_EXAMPLES_DIR) \
 		--ignore $(XPKG_IGNORE) \


### PR DESCRIPTION
### Description of your changes

To make recently introduced xpkg build functionality work with configuration packages as well, we will be passing `--controller` argument to xpkg build command only for provider packages.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).

### How has this code been tested

Together with [platform-ref-gcp](https://github.com/upbound/platform-ref-gcp) with `make build` using the following Makefile:

```
# Project Setup
PROJECT_NAME := platform-ref-gcp
PROJECT_REPO := github.com/upbound/$(PROJECT_NAME)

PLATFORMS ?= linux_amd64 linux_arm64
include build/makelib/common.mk

# ====================================================================================
# Setup Kubernetes tools

UP_VERSION = v0.13.0
UP_CHANNEL = stable

-include build/makelib/k8s_tools.mk
# ====================================================================================
# Setup XPKG

XPKG_REG_ORGS ?= xpkg.upbound.io/upbound
# NOTE(hasheddan): skip promoting on xpkg.upbound.io as channel tags are
# inferred.
XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/upbound
XPKGS = $(PROJECT_NAME)
-include build/makelib/xpkg.mk

# ====================================================================================
# Targets

# NOTE(hasheddan): we must ensure up is installed in tool cache prior to build
# as including the k8s_tools machinery prior to the xpkg machinery sets UP to
# point to tool cache.
build.init: $(UP)
```
