### PR TITLE
Add targets to deploy a locally build configuration package

### DIFF
--- a/makelib/controlplane.mk
+++ b/makelib/controlplane.mk
@@ -1,0 +1,27 @@
+# Copyright 2022 The Upbound Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+KIND_CLUSTER_NAME ?= uptest
+
+controlplane.up: $(UP) $(KUBECTL) $(KIND)
+	@$(INFO) setting up controlplane
+	@$(KIND) get kubeconfig --name $(KIND_CLUSTER_NAME) >/dev/null 2>&1 || $(KIND) create cluster --name=$(KIND_CLUSTER_NAME)
+	@$(KUBECTL) -n upbound-system get cm universal-crossplane-config >/dev/null 2>&1 || $(UP) uxp install
+	@$(KUBECTL) -n upbound-system wait deploy crossplane --for condition=Available --timeout=120s
+	@$(OK) setting up controlplane
+
+controlplane.down: $(UP) $(KUBECTL) $(KIND)
+	@$(INFO) deleting controlplane
+	@$(KIND) delete cluster --name=$(KIND_CLUSTER_NAME)
+	@$(OK) deleting controlplane

--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -25,7 +25,7 @@ ISTIO_DOWNLOAD_TUPLE := osx-$(SAFEHOSTARCH)
 endif
 
 # the version of kind to use
-KIND_VERSION ?= v0.14.0
+KIND_VERSION ?= v0.16.0
 KIND := $(TOOLS_HOST_DIR)/kind-$(KIND_VERSION)
 
 # the version of kubectl to use

--- a/makelib/local.xpkg.mk
+++ b/makelib/local.xpkg.mk
@@ -31,7 +31,7 @@ local.xpkg.sync: local.xpkg.init $(UP)
 		$(KUBECTL) -n $(CROSSPLANE_NAMESPACE) cp $(XPKG_OUTPUT_DIR)/cache -c dev $$XPPOD:/tmp
 	@$(OK) copying local xpkg cache to Crossplane pod
 
-local.xpkg.deploy.%: local.xpkg.sync
-	@$(INFO) deploying xpkg $* $(VERSION)
+local.xpkg.deploy-cfg.%: local.xpkg.sync
+	@$(INFO) deploying configuration package $* $(VERSION)
 	@echo '{"apiVersion":"pkg.crossplane.io/v1","kind":"Configuration","metadata":{"name":"$*"},"spec":{"package":"$*-$(VERSION).gz","packagePullPolicy":"Never"}}' | $(KUBECTL) apply -f -
-	@$(OK) deploying xpkg $* $(VERSION)
+	@$(OK) deploying configuration package $* $(VERSION)

--- a/makelib/local.xpkg.mk
+++ b/makelib/local.xpkg.mk
@@ -1,0 +1,37 @@
+# Copyright 2022 The Upbound Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CROSSPLANE_NAMESPACE ?= crossplane-system
+
+local.xpkg.init: $(KUBECTL)
+	@$(INFO) patching Crossplane with dev sidecar
+	@if ! $(KUBECTL) -n $(CROSSPLANE_NAMESPACE) get deployment crossplane -o jsonpath="{.spec.template.spec.containers[*].name}" | grep "dev" > /dev/null; then \
+		$(KUBECTL) -n $(CROSSPLANE_NAMESPACE) patch deployment/crossplane --type='json' -p='[{"op":"add","path":"/spec/template/spec/containers/1","value":{"image":"nginx","imagePullPolicy":"Always","name":"dev","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/tmp/cache","name":"package-cache"}]}},{"op":"add","path":"/spec/template/metadata/labels/patched","value":"true"}]'; \
+		$(KUBECTL) -n $(CROSSPLANE_NAMESPACE) wait deploy crossplane --for condition=Available --timeout=60s; \
+		$(KUBECTL) -n $(CROSSPLANE_NAMESPACE) wait pods -l app=crossplane,patched=true --for condition=Ready --timeout=60s; \
+	fi
+	@$(OK) patching Crossplane with dev sidecar
+
+local.xpkg.sync: local.xpkg.init $(UP)
+	@$(INFO) copying local xpkg cache to Crossplane pod
+	@mkdir -p $(XPKG_OUTPUT_DIR)/cache
+	@for pkg in $(XPKG_OUTPUT_DIR)/linux_*/*; do $(UP) xpkg xp-extract --from-xpkg $$pkg -o $(XPKG_OUTPUT_DIR)/cache/$$(basename $$pkg .xpkg).gz; done
+	@XPPOD=$$($(KUBECTL) -n $(CROSSPLANE_NAMESPACE) get pod -l app=crossplane,patched=true -o jsonpath="{.items[0].metadata.name}"); \
+		$(KUBECTL) -n $(CROSSPLANE_NAMESPACE) cp $(XPKG_OUTPUT_DIR)/cache -c dev $$XPPOD:/tmp
+	@$(OK) copying local xpkg cache to Crossplane pod
+
+local.xpkg.deploy.%: local.xpkg.sync
+	@$(INFO) deploying xpkg $* $(VERSION)
+	@echo '{"apiVersion":"pkg.crossplane.io/v1","kind":"Configuration","metadata":{"name":"$*"},"spec":{"package":"$*-$(VERSION).gz","packagePullPolicy":"Never"}}' | $(KUBECTL) apply -f -
+	@$(OK) deploying xpkg $* $(VERSION)


### PR DESCRIPTION
### Description of your changes

Adds targets to deploy a locally build configuration package.

It also adds targets to start and stop a control plane (a.k.a. K8s + XP)

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).

### How has this code been tested

With this PR: https://github.com/upbound/platform-ref-gcp/pull/25
See `uptest` target.
