### PR TITLE
common: adopt make 4 changes around how to define space

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -258,8 +258,8 @@ version.isdirty:
 SED_CMD?=sed -i -e
 
 COMMA := ,
-SPACE :=
-SPACE +=
+EMPTY :=
+SPACE := $(EMPTY) $(EMPTY)
 
 # define a newline
 define \n


### PR DESCRIPTION
### Description of your changes

In my local with make 3.8, `IMAGE_PLATFORMS` is calculated as `linux/amd64,linux/arm64` but in Ubuntu 22.04, make version is 4.3 and it calculates it as `linux/amd64 linux/arm64,` which breaks `imagelight.mk`. I've seen this [in CI ](https://github.com/upbound/provider-aws/actions/runs/3205351360/jobs/5237762811)and I was able to reproduce it in a Ubuntu 22.04 docker container.

What's going on is that apparently, `SPACE` definition we had is not compatible with the newer version and others have also struggled to define space character in Make. After digging, I found this trick (discussed [here](https://groups.google.com/g/gnu.utils.help/c/Kph-2Mk4NxU/m/QQMgBYynsuAJ)) which looks pretty explicit and proved to to work.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manually with both make 4.3 (GNU) and 3.8 (Apple) by running `make -n publish BRANCH_NAME=main` with both and seeing `IMAGE_PLATFORMS=linux/amd64,linux/arm64` in the last command.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
