### PR TITLE
common: calculate major, minor and patch versions correctly

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -226,9 +226,16 @@ export VERSION
 
 VERSION_REGEX := ^v\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)$$
 VERSION_VALID := $(shell echo "$(VERSION)" | grep -q '$(VERSION_REGEX)' && echo 1 || echo 0)
-VERSION_MAJOR := $(shell echo "$(VERSION)" | sed -e 's/$(VERSION_REGEX)/\1/')
-VERSION_MINOR := $(shell echo "$(VERSION)" | sed -e 's/$(VERSION_REGEX)/\2/')
-VERSION_PATCH := $(shell echo "$(VERSION)" | sed -e 's/$(VERSION_REGEX)/\3/')
+
+# Given "v0.17.0-3.gb4eee9f.dirty" it returns "0".
+VERSION_MAJOR := $(shell echo "$(VERSION)" | cut -d'.' -f1 | sed '1s/^.//')
+
+# Given "v0.17.0-3.gb4eee9f.dirty" it returns "17".
+VERSION_MINOR := $(shell echo "$(VERSION)" | cut -d'.' -f2)
+
+# Given "v0.17.0-3.gb4eee9f.dirty" it returns "0-3.gb4eee9f.dirty".
+# Given "v0.17.1" it returns "1".
+VERSION_PATCH := $(shell echo "$(VERSION)" | cut -d'.' -f3-)
 
 release.tag:
 ifneq ($(VERSION_VALID),1)


### PR DESCRIPTION
### Description of your changes

As described in https://github.com/upbound/build/issues/211 , the current calculations of these variables are wrong if the version has more than 2 `.` characters.

Fixes https://github.com/upbound/build/issues/211

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Dirty version:
```bash
export VERSION="v0.17.0-3.gb4eee9f.dirty"
export VERSION_MAJOR=$(echo "${VERSION}" | cut -d'.' -f1 | sed '1s/^.//')
export VERSION_MINOR=$(echo "${VERSION}" | cut -d'.' -f2)
export VERSION_PATCH=$(echo "${VERSION}" | cut -d'.' -f3-)
```
```bash
echo ${VERSION_MAJOR} # 0
echo ${VERSION_MINOR} # 17
echo ${VERSION_PATCH} # 0-3.gb4eee9f.dirty
```

Normal tag version:
```bash
export VERSION="v0.17.1"
export VERSION_MAJOR=$(echo "${VERSION}" | cut -d'.' -f1 | sed '1s/^.//')
export VERSION_MINOR=$(echo "${VERSION}" | cut -d'.' -f2)
export VERSION_PATCH=$(echo "${VERSION}" | cut -d'.' -f3-)
```
```bash
echo ${VERSION_MAJOR} # 0
echo ${VERSION_MINOR} # 17
echo ${VERSION_PATCH} # 1
```

Also tested in a repo and confirmed that we're getting correct values now.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
