### PR TITLE
Enhance docs local development capabilities

### DIFF
--- a/makelib/docs.mk
+++ b/makelib/docs.mk
@@ -52,6 +52,9 @@ docs.generate:
 docs.run: docs.generate
 	cd $(DOCS_WORK_DIR) && DOCS_VERSION=$(DOCS_VERSION) $(MAKE) run
 
+docs.validate: docs.generate
+	cd $(DOCS_WORK_DIR) && DOCS_VERSION=$(DOCS_VERSION) $(MAKE) validate
+
 docs.publish: docs.generate
 	cd $(DOCS_WORK_DIR) && DOCS_VERSION=$(DOCS_VERSION) $(MAKE) publish
 

--- a/makelib/docs.mk
+++ b/makelib/docs.mk
@@ -38,7 +38,7 @@ DOCS_VERSION_DIR := $(DOCS_WORK_DIR)/$(DEST_DOCS_DIR)/$(DOCS_VERSION)
 # ====================================================================================
 # Targets
 
-docs.publish:
+docs.generate:
 	rm -rf $(DOCS_WORK_DIR)
 	mkdir -p $(DOCS_WORK_DIR)
 	git clone --depth=1 -b master $(DOCS_GIT_REPO) $(DOCS_WORK_DIR)
@@ -48,6 +48,11 @@ docs.publish:
 		cp -r $(SOURCE_DOCS_DIR)/ $(DOCS_VERSION_DIR); \
 		$(OK) Version included in documentation ; \
 	fi
+
+docs.run: docs.generate
+	cd $(DOCS_WORK_DIR) && DOCS_VERSION=$(DOCS_VERSION) $(MAKE) run
+
+docs.publish: docs.generate
 	cd $(DOCS_WORK_DIR) && DOCS_VERSION=$(DOCS_VERSION) $(MAKE) publish
 
 # ====================================================================================

--- a/makelib/docs.mk
+++ b/makelib/docs.mk
@@ -31,7 +31,7 @@ endif
 # documentation repository.
 DOCS_VERSION_ACTIVE ?= true
 
-DOCS_VERSION := $(shell echo "$(BRANCH_NAME)" | sed -E "s/^release\-([0-9]+)\.([0-9]+)$$/v\1.\2/g")
+DOCS_VERSION ?= $(shell echo "$(BRANCH_NAME)" | sed -E "s/^release\-([0-9]+)\.([0-9]+)$$/v\1.\2/g")
 DOCS_WORK_DIR := $(WORK_DIR)/docs-repo
 DOCS_VERSION_DIR := $(DOCS_WORK_DIR)/$(DEST_DOCS_DIR)/$(DOCS_VERSION)
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds support for overriding the version of the documentation being
produced, which can be useful for local development.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Separates docs generation and publishing, and adds a run target that
just calls make again on the docs repo run target.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Verified ability to run locally with https://github.com/crossplane/crossplane.github.io/pull/166 and https://github.com/crossplane/crossplane/pull/3373