### PR TITLE
Add uptest tool

### DIFF
--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -63,6 +63,9 @@ endif
 KUTTL_VERSION ?= 0.12.1
 KUTTL := $(TOOLS_HOST_DIR)/kuttl-$(KUTTL_VERSION)
 
+# the version of uptest to use
+UPTEST_VERSION ?= v0.1.0
+UPTEST := $(TOOLS_HOST_DIR)/uptest-$(UPTEST_VERSION)
 # ====================================================================================
 # Common Targets
 
@@ -154,3 +157,11 @@ $(KUTTL):
 	@curl -fsSLo $(KUTTL) --create-dirs https://github.com/kudobuilder/kuttl/releases/download/v$(KUTTL_VERSION)/kubectl-kuttl_$(KUTTL_VERSION)_$(HOST_PLATFORM) || $(FAIL)
 	@chmod +x $(KUTTL)
 	@$(OK) installing kuttl $(KUTTL_VERSION)
+
+# uptest download and install
+$(UPTEST):
+	@$(INFO) installing uptest $(UPTEST)
+	@curl -fsSLo $(UPTEST) https://github.com/upbound/uptest/releases/download/$(UPTEST_VERSION)/uptest_$(SAFEHOSTPLATFORM) || $(FAIL)
+	@chmod +x $(UPTEST)
+	@$(OK) installing uptest $(UPTEST)
+


### PR DESCRIPTION
### Description of your changes

This PR is adding uptest as a tool.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

With the following target:

```makefile
testing-uptest: $(UPTEST)
	$(UPTEST) --help
```
