### PR TITLE
Add control plane dump target

### DIFF
--- a/makelib/controlplane.mk
+++ b/makelib/controlplane.mk
@@ -14,6 +14,8 @@
 
 KIND_CLUSTER_NAME ?= uptest
 
+CONTROLPLANE_DUMP_DIRECTORY ?= $(OUTPUT_DIR)/controlplane-dump
+
 controlplane.up: $(UP) $(KUBECTL) $(KIND)
 	@$(INFO) setting up controlplane
 	@$(KIND) get kubeconfig --name $(KIND_CLUSTER_NAME) >/dev/null 2>&1 || $(KIND) create cluster --name=$(KIND_CLUSTER_NAME)
@@ -25,3 +27,8 @@ controlplane.down: $(UP) $(KUBECTL) $(KIND)
 	@$(INFO) deleting controlplane
 	@$(KIND) delete cluster --name=$(KIND_CLUSTER_NAME)
 	@$(OK) deleting controlplane
+
+controlplane.dump: $(KUBECTL)
+	mkdir -p $(CONTROLPLANE_DUMP_DIRECTORY)
+	@$(KUBECTL) cluster-info dump --output-directory $(CONTROLPLANE_DUMP_DIRECTORY) --all-namespaces || true
+	@$(KUBECTL) get managed -o yaml > $(CONTROLPLANE_DUMP_DIRECTORY)/managed.yaml || true


### PR DESCRIPTION
### Description of your changes

Adds `controlplane.dump` target to dump cluster information for debugging/troubleshooting.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Together with https://github.com/upbound/platform-ref-azure/pull/20
