### PR TITLE
Dump Crossplane resources as well

### DIFF
--- a/makelib/controlplane.mk
+++ b/makelib/controlplane.mk
@@ -31,4 +31,5 @@ controlplane.down: $(UP) $(KUBECTL) $(KIND)
 controlplane.dump: $(KUBECTL)
 	mkdir -p $(CONTROLPLANE_DUMP_DIRECTORY)
 	@$(KUBECTL) cluster-info dump --output-directory $(CONTROLPLANE_DUMP_DIRECTORY) --all-namespaces || true
-	@$(KUBECTL) get managed -o yaml > $(CONTROLPLANE_DUMP_DIRECTORY)/managed.yaml || true
+	@$(KUBECTL) get crossplane --all-namespaces > $(CONTROLPLANE_DUMP_DIRECTORY)/all-crossplane.txt || true
+	@$(KUBECTL) get crossplane --all-namespaces -o yaml > $(CONTROLPLANE_DUMP_DIRECTORY)/all-crossplane.yaml || true


### PR DESCRIPTION
### Description of your changes

Extends `controlplane.dump` target further with Crossplane resources as suggested by @muvaf [here](https://github.com/upbound/build/pull/215#issuecomment-1284458650).

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Tested each command individually.
