### PR TITLE
Add support for Provider in local.xpkg.deploy

### DIFF
--- a/makelib/controlplane.mk
+++ b/makelib/controlplane.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KIND_CLUSTER_NAME ?= uptest
+KIND_CLUSTER_NAME ?= local-dev
 
 CONTROLPLANE_DUMP_DIRECTORY ?= $(OUTPUT_DIR)/controlplane-dump
 


### PR DESCRIPTION
### Description of your changes

This PR aims to simplify provider deployment currently achieved by scripts like [this](https://github.com/upbound/provider-aws/blob/main/cluster/install_provider.sh) by extending recently added local.xpkg.deploy target with Provider support.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Tested with [provider-civo](https://github.com/crossplane-contrib/provider-civo) by adding the following lines to Makefile:

```Make
CROSSPLANE_NAMESPACE = upbound-system
-include build/makelib/local.xpkg.mk
-include build/makelib/controlplane.mk
```

Then run

```
make controlplane.up build local.xpkg.deploy.provider.provider-civo
```

Check the status of the provider:

```shell
kubectl get provider.pkg
NAME            INSTALLED   HEALTHY   PACKAGE                       AGE
provider-civo   True        True      provider-civo-v0.1-dirty.gz   68s

kubectl -n upbound-system get pods
NAME                                          READY   STATUS    RESTARTS      AGE
crossplane-7f677d4c5b-d7nzk                   2/2     Running   0             91s
crossplane-rbac-manager-789f7ccdc7-qqc59      1/1     Running   0             2m4s
provider-civo-provider-civ-5f967d9ffc-8gzlr   1/1     Running   0             21s
upbound-bootstrapper-689bdfdd95-tmskf         1/1     Running   0             2m4s
xgql-8fb949dcf-mwz9m                          1/1     Running   3 (99s ago)   2m4s
```



