### PR TITLE
golang: remove go version check

### DIFF
--- a/makelib/golang.mk
+++ b/makelib/golang.mk
@@ -18,9 +18,6 @@
 # Optional. The Go Binary to use
 GO ?= go
 
-# Optional. Required Go version.
-GO_REQUIRED_VERSION ?= 1.18
-
 # The go project including repo name, for example, github.com/rook/rook
 GO_PROJECT ?= $(PROJECT_REPO)
 
@@ -89,9 +86,6 @@ GOIMPORTS_VERSION ?= v0.1.12
 
 GOHOST := GOOS=$(GOHOSTOS) GOARCH=$(GOHOSTARCH) $(GO)
 GO_VERSION := $(shell $(GO) version | sed -ne 's/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9][^.]\).*/\1/p')
-ifneq ($(GO_VERSION),$(GO_REQUIRED_VERSION))
-$(error "$(GO) version $(GO_VERSION) is not supported. required version is $(GO_REQUIRED_VERSION)")
-endif
 
 # we use a consistent version of gofmt even while running different go compilers.
 # see https://github.com/golang/go/issues/26397 for more details


### PR DESCRIPTION
### Description of your changes

It's been getting in the way unexpected places as discussed [here](https://github.com/upbound/build/pull/200) and [here](https://github.com/upbound/build/pull/195). And it'd been removed once in the past [here](https://github.com/upbound/build/pull/140). Recently, it blocked the UXP release because [promote job](https://github.com/upbound/universal-crossplane/actions/runs/3401410191/jobs/5656492204) didn't have a correct Go version, which is unrelated to what it does - it probably shouldn't include `golang.mk` anyway, but the way Makefiles are structured, everything is included during invocation of any target.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Ran `make reviewable` on UXP repo after downgrading to 1.18 and it worked as expected when I ran `make reviewable` with go 1.19.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
