### PR TITLE
Separate docs generation from running locally

### DIFF
--- a/makelib/docs.mk
+++ b/makelib/docs.mk
@@ -38,18 +38,25 @@ DOCS_VERSION_DIR := $(DOCS_WORK_DIR)/$(DEST_DOCS_DIR)/$(DOCS_VERSION)
 # ====================================================================================
 # Targets
 
-docs.generate:
+docs.init:
 	rm -rf $(DOCS_WORK_DIR)
 	mkdir -p $(DOCS_WORK_DIR)
 	git clone --depth=1 -b master $(DOCS_GIT_REPO) $(DOCS_WORK_DIR)
+
+docs.generate: docs.init
 	rm -rf $(DOCS_VERSION_DIR)
+	@if [ "$(DOCS_VERSION_ACTIVE)" == "true" ]; then \
+		$(INFO) Including version in documentation ; \
+		cp -r $(SOURCE_DOCS_DIR)/ $(DOCS_VERSION_DIR); \
+		$(OK) Version included in documentation ; \
+	fi
+
+docs.run: docs.init
 	@if [ "$(DOCS_VERSION_ACTIVE)" == "true" ]; then \
 		$(INFO) Including version in documentation ; \
 		ln -s $(ROOT_DIR)/$(SOURCE_DOCS_DIR) $(DOCS_VERSION_DIR); \
 		$(OK) Version included in documentation ; \
 	fi
-
-docs.run: docs.generate
 	cd $(DOCS_WORK_DIR) && DOCS_VERSION=$(DOCS_VERSION) $(MAKE) run
 
 docs.validate: docs.generate


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates docs machinery to be able to symlink when running locally but copy fully when generating for publish.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Ran in crossplane/crossplane and verified that `make docs.run` and `make publish` worked correctly.