### PR TITLE
fix(docs): Run npm install on docs.init

### DIFF
--- a/makelib/docs.mk
+++ b/makelib/docs.mk
@@ -42,6 +42,7 @@ docs.init:
 	rm -rf $(DOCS_WORK_DIR)
 	mkdir -p $(DOCS_WORK_DIR)
 	git clone --depth=1 -b master $(DOCS_GIT_REPO) $(DOCS_WORK_DIR)
+	(cd $(DOCS_WORK_DIR) && $(MAKE) npm.install)
 
 docs.generate: docs.init
 	rm -rf $(DOCS_VERSION_DIR)


### PR DESCRIPTION
### Description of your changes

Fix error in pipeline due to missing node packages, such as

```
Error: Error building site: POSTCSS: failed to transform "scss/docs.css" (text/css). Check your PostCSS installation; install with "npm install postcss-cli". See https://gohugo.io/hugo-pipes/postcss/: this feature is not available in your current Hugo version, see https://goo.gl/YMrWcn for more information
```

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manually