### PR TITLE
Remove docs publishing and version-specific changes

### DIFF
--- a/makelib/docs.mk
+++ b/makelib/docs.mk
@@ -15,25 +15,11 @@
 # ====================================================================================
 # Options
 
-ifndef SOURCE_DOCS_DIR
-$(error SOURCE_DOCS_DIR must be defined)
-endif
-
-ifndef DEST_DOCS_DIR
-$(error DEST_DOCS_DIR must be defined)
-endif
-
 ifndef DOCS_GIT_REPO
 $(error DOCS_GIT_REPO must be defined)
 endif
 
-# Optional. If false the publish step will remove this version from the
-# documentation repository.
-DOCS_VERSION_ACTIVE ?= true
-
-DOCS_VERSION ?= $(shell echo "$(BRANCH_NAME)" | sed -E "s/^release\-([0-9]+)\.([0-9]+)$$/v\1.\2/g")
 DOCS_WORK_DIR := $(WORK_DIR)/docs-repo
-DOCS_VERSION_DIR := $(DOCS_WORK_DIR)/$(DEST_DOCS_DIR)/$(DOCS_VERSION)
 
 # ====================================================================================
 # Targets
@@ -43,32 +29,12 @@ docs.init:
 	mkdir -p $(DOCS_WORK_DIR)
 	git clone --depth=1 -b master $(DOCS_GIT_REPO) $(DOCS_WORK_DIR)
 
-docs.generate: docs.init
-	rm -rf $(DOCS_VERSION_DIR)
-	@if [ "$(DOCS_VERSION_ACTIVE)" == "true" ]; then \
-		$(INFO) Including version in documentation ; \
-		cp -r $(SOURCE_DOCS_DIR)/ $(DOCS_VERSION_DIR); \
-		$(OK) Version included in documentation ; \
-	fi
-
 docs.run: docs.init
-	@if [ "$(DOCS_VERSION_ACTIVE)" == "true" ]; then \
-		$(INFO) Including version in documentation ; \
-		ln -s $(ROOT_DIR)/$(SOURCE_DOCS_DIR) $(DOCS_VERSION_DIR); \
-		$(OK) Version included in documentation ; \
-	fi
-	cd $(DOCS_WORK_DIR) && DOCS_VERSION=$(DOCS_VERSION) $(MAKE) run
+	cd $(DOCS_WORK_DIR) $(MAKE) run
 
 docs.validate: docs.generate
-	cd $(DOCS_WORK_DIR) && DOCS_VERSION=$(DOCS_VERSION) $(MAKE) validate
+	cd $(DOCS_WORK_DIR) $(MAKE) validate
 
-docs.publish: docs.generate
-	cd $(DOCS_WORK_DIR) && DOCS_VERSION=$(DOCS_VERSION) $(MAKE) publish
 
 # ====================================================================================
 # Common Targets
-
-# only publish docs for master and release branches
-ifneq ($(filter master release-%,$(BRANCH_NAME)),)
-publish.artifacts: docs.publish
-endif

--- a/makelib/docs.mk
+++ b/makelib/docs.mk
@@ -32,7 +32,7 @@ docs.init:
 docs.run: docs.init
 	cd $(DOCS_WORK_DIR) $(MAKE) run
 
-docs.validate: docs.generate
+docs.validate:
 	cd $(DOCS_WORK_DIR) $(MAKE) validate
 
 


### PR DESCRIPTION
### Description of your changes
This removes `docs.publish` and all version related actions for docs. 

This is related to crossplane/crossplane issue [#3461](https://github.com/crossplane/crossplane/issues/3461), moving the docs out of the crossplane/crossplane repo. 

Other docs make options are left in case a crossplane developer need to build docs locally for some reason. 

Signed-off-by: Pete Lumbis <pete@upbound.io>