### PR TITLE
Add check diff error message

### DIFF
--- a/makelib/common.mk
+++ b/makelib/common.mk
@@ -443,7 +443,7 @@ reviewable:
 # ensure generate target doesn't create a diff
 check-diff: generate
 	@$(INFO) checking that branch is clean
-	@if git status --porcelain | grep . ; then $(FAIL); else $(OK) branch is clean; fi
+	@if git status --porcelain | grep . ; then $(ERR) There are uncommitted changes after running make generate. Please ensure you commit all generated files in this branch after running make generate. && false; else $(OK) branch is clean; fi
 
 .PHONY: publish.init publish.artifacts publish promote.init promote.artifacts promote tag generate reviewable check-diff
 


### PR DESCRIPTION
### Description of your changes

This PR added an error message for failing check diff.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manually tested with provider-gcp
<img width="833" alt="Screenshot 2023-03-28 at 14 23 20" src="https://user-images.githubusercontent.com/103541666/228220971-19b8fa33-a36b-43f7-b325-6879c2332524.png">
