### PR TITLE
feat: generate helm chart README with helm-docs

### DIFF
--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -93,9 +93,7 @@ helm.generate.$(1): $(HELM_HOME) $(HELM_DOCS)
 		$(OK) helm-docs $(1) [disabled]; \
 	else \
 		$(INFO) helm-docs $(1); \
-		$(MAKE) VERSION="master" helm.prepare.$(1); \
-		cd $(HELM_CHARTS_DIR)/$(1) && $(HELM_DOCS); \
-		rm -f $(HELM_CHARTS_DIR)/$(1)/values.yaml; \
+		$(MAKE) VERSION="master" HELM_DOCS_PREPARE="true" helm.prepare.$(1); \
 		$(OK) helm-docs $(1); \
 	fi
 
@@ -105,6 +103,10 @@ helm.generate: helm.generate.$(1)
 helm.prepare.$(1): $(HELM_HOME)
 	@cp -f $(HELM_CHARTS_DIR)/$(1)/values.yaml.tmpl $(HELM_CHARTS_DIR)/$(1)/values.yaml
 	@cd $(HELM_CHARTS_DIR)/$(1) && $(SED_CMD) 's|%%VERSION%%|$(VERSION)|g' values.yaml
+	@if [ "$(HELM_DOCS_PREPARE)" == "true" ]; then \
+		$(HELM_DOCS); \
+		rm -f $(HELM_CHARTS_DIR)/$(1)/values.yaml; \
+	fi
 
 helm.prepare: helm.prepare.$(1)
 

--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -93,9 +93,10 @@ $(HELM_OUTPUT_DIR)/$(1)-$(HELM_CHART_VERSION).tgz: $(HELM_HOME) $(HELM_OUTPUT_DI
 helm.generate.$(1): $(HELM_HOME) $(HELM_DOCS)
 	@$(INFO) helm-docs $(1)
 ifneq ($(HELM_DOCS_ENABLED),true)
-	@$(OK) helm-docs $(1) [skipped]
+	@$(OK) helm docs not enabled [skipped]
+else ifneq ($(HELM_VALUES_TEMPLATE_SKIPPED),true)
+	@$(WARN) helm-docs not supported with templated values.yaml [skipped]
 else
-	@$(MAKE) VERSION="master" HELM_PREPARE_CLEANUP="true" helm.prepare.$(1)
 	@$(HELM_DOCS)
 	@$(OK) helm-docs $(1)
 endif
@@ -105,13 +106,11 @@ helm.generate: helm.generate.$(1)
 helm.prepare.$(1): $(HELM_HOME)
 	@$(INFO) helm prepare $(1)
 ifeq ($(HELM_VALUES_TEMPLATE_SKIPPED),true)
-		@$(OK) helm prepare $(1) [skipped]
+	@$(OK) HELM_VALUES_TEMPLATE_SKIPPED set to true [skipped]
 else
+	@$(WARN) templating helm values.yaml for %%VERSION%% is deprecated, use appVersion and an empty tag instead.
 	@cp -f $(HELM_CHARTS_DIR)/$(1)/values.yaml.tmpl $(HELM_CHARTS_DIR)/$(1)/values.yaml
 	@cd $(HELM_CHARTS_DIR)/$(1) && $(SED_CMD) 's|%%VERSION%%|$(VERSION)|g' values.yaml
-	@if [ "$(HELM_PREPARE_CLEANUP)" == "true" ]; then \
-		rm -f $(HELM_CHARTS_DIR)/$(1)/values.yaml; \
-	fi
 	@$(OK) helm prepare $(1)
 endif
 

--- a/makelib/helm.mk
+++ b/makelib/helm.mk
@@ -89,11 +89,12 @@ $(HELM_OUTPUT_DIR)/$(1)-$(HELM_CHART_VERSION).tgz: $(HELM_HOME) $(HELM_OUTPUT_DI
 	@$(OK) helm package $(1) $(HELM_CHART_VERSION)
 
 helm.generate.$(1): $(HELM_HOME) $(HELM_DOCS)
+	@$(INFO) helm-docs $(1)
 	@if [ "$(HELM_DOCS_ENABLED)" != "true" ]; then \
 		$(OK) helm-docs $(1) [disabled]; \
 	else \
-		$(INFO) helm-docs $(1); \
-		$(MAKE) VERSION="master" HELM_DOCS_PREPARE="true" helm.prepare.$(1); \
+		$(MAKE) VERSION="master" HELM_PREPARE_CLEANUP="true" helm.prepare.$(1); \
+		$(HELM_DOCS); \
 		$(OK) helm-docs $(1); \
 	fi
 
@@ -103,8 +104,7 @@ helm.generate: helm.generate.$(1)
 helm.prepare.$(1): $(HELM_HOME)
 	@cp -f $(HELM_CHARTS_DIR)/$(1)/values.yaml.tmpl $(HELM_CHARTS_DIR)/$(1)/values.yaml
 	@cd $(HELM_CHARTS_DIR)/$(1) && $(SED_CMD) 's|%%VERSION%%|$(VERSION)|g' values.yaml
-	@if [ "$(HELM_DOCS_PREPARE)" == "true" ]; then \
-		$(HELM_DOCS); \
+	@if [ "$(HELM_PREPARE_CLEANUP)" == "true" ]; then \
 		rm -f $(HELM_CHARTS_DIR)/$(1)/values.yaml; \
 	fi
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds helm chart's README generation using github.com/norwoodj/helm-docs/cmd/helm-docs.

This should be explicitly enabled by the callers by setting `HELM_DOCS_ENABLED = true`, this way we won't overwrite existing READMEs.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

`make HELM_DOCS_ENABLED=true helm.generate` properly generates the crossplane helm chart README in https://github.com/crossplane/crossplane/pull/3978 if the proper template is specified as in the PR description.

It's also properly run when running `make check-diff`.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
