### PR TITLE
Make Crossplane namespace configurable for controlplane.up

### DIFF
--- a/makelib/controlplane.mk
+++ b/makelib/controlplane.mk
@@ -13,14 +13,15 @@
 # limitations under the License.
 
 KIND_CLUSTER_NAME ?= local-dev
+CROSSPLANE_NAMESPACE ?= upbound-system
 
 CONTROLPLANE_DUMP_DIRECTORY ?= $(OUTPUT_DIR)/controlplane-dump
 
 controlplane.up: $(UP) $(KUBECTL) $(KIND)
 	@$(INFO) setting up controlplane
 	@$(KIND) get kubeconfig --name $(KIND_CLUSTER_NAME) >/dev/null 2>&1 || $(KIND) create cluster --name=$(KIND_CLUSTER_NAME)
-	@$(KUBECTL) -n upbound-system get cm universal-crossplane-config >/dev/null 2>&1 || $(UP) uxp install
-	@$(KUBECTL) -n upbound-system wait deploy crossplane --for condition=Available --timeout=120s
+	@$(KUBECTL) -n $(CROSSPLANE_NAMESPACE) get cm universal-crossplane-config >/dev/null 2>&1 || $(UP) uxp install --namespace=$(CROSSPLANE_NAMESPACE)
+	@$(KUBECTL) -n $(CROSSPLANE_NAMESPACE) wait deploy crossplane --for condition=Available --timeout=120s
 	@$(OK) setting up controlplane
 
 controlplane.down: $(UP) $(KUBECTL) $(KIND)

--- a/makelib/local.xpkg.mk
+++ b/makelib/local.xpkg.mk
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 KIND_CLUSTER_NAME ?= local-dev
-CROSSPLANE_NAMESPACE ?= crossplane-system
+CROSSPLANE_NAMESPACE ?= upbound-system
 
 local.xpkg.init: $(KUBECTL)
 	@$(INFO) patching Crossplane with dev sidecar


### PR DESCRIPTION
### Description of your changes

This PR makes the Crossplane namespace configurable for `controlplane.up` command.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Together with https://github.com/crossplane-contrib/provider-kubernetes/pull/120

```
make e2e
```
