### PR TITLE
Support skipping dependency resolution of installed Crossplane packages in target local.xpkg.init

### DIFF
--- a/makelib/local.xpkg.mk
+++ b/makelib/local.xpkg.mk
@@ -14,6 +14,7 @@
 
 KIND_CLUSTER_NAME ?= local-dev
 CROSSPLANE_NAMESPACE ?= upbound-system
+XPKG_SKIP_DEP_RESOLUTION ?= false
 
 local.xpkg.init: $(KUBECTL)
 	@$(INFO) patching Crossplane with dev sidecar
@@ -41,5 +42,5 @@ local.xpkg.deploy.provider.%: $(KIND) local.xpkg.sync
 	@$(INFO) deploying provider package $* $(VERSION)
 	@$(KIND) load docker-image $(BUILD_REGISTRY)/$*-$(ARCH) -n $(KIND_CLUSTER_NAME)
 	@echo '{"apiVersion":"pkg.crossplane.io/v1alpha1","kind":"ControllerConfig","metadata":{"name":"config"},"spec":{"args":["-d"],"image":"$(BUILD_REGISTRY)/$*-$(ARCH)"}}' | $(KUBECTL) apply -f -
-	@echo '{"apiVersion":"pkg.crossplane.io/v1","kind":"Provider","metadata":{"name":"$*"},"spec":{"package":"$*-$(VERSION).gz","packagePullPolicy":"Never","controllerConfigRef":{"name":"config"}}}' | $(KUBECTL) apply -f -
+	@echo '{"apiVersion":"pkg.crossplane.io/v1","kind":"Provider","metadata":{"name":"$*"},"spec":{"package":"$*-$(VERSION).gz","skipDependencyResolution": $(XPKG_SKIP_DEP_RESOLUTION), "packagePullPolicy":"Never","controllerConfigRef":{"name":"config"}}}' | $(KUBECTL) apply -f -
 	@$(OK) deploying provider package $* $(VERSION)

--- a/makelib/local.xpkg.mk
+++ b/makelib/local.xpkg.mk
@@ -41,6 +41,6 @@ local.xpkg.deploy.configuration.%: local.xpkg.sync
 local.xpkg.deploy.provider.%: $(KIND) local.xpkg.sync
 	@$(INFO) deploying provider package $* $(VERSION)
 	@$(KIND) load docker-image $(BUILD_REGISTRY)/$*-$(ARCH) -n $(KIND_CLUSTER_NAME)
-	@echo '{"apiVersion":"pkg.crossplane.io/v1alpha1","kind":"ControllerConfig","metadata":{"name":"config"},"spec":{"args":["-d"],"image":"$(BUILD_REGISTRY)/$*-$(ARCH)"}}' | $(KUBECTL) apply -f -
-	@echo '{"apiVersion":"pkg.crossplane.io/v1","kind":"Provider","metadata":{"name":"$*"},"spec":{"package":"$*-$(VERSION).gz","skipDependencyResolution": $(XPKG_SKIP_DEP_RESOLUTION), "packagePullPolicy":"Never","controllerConfigRef":{"name":"config"}}}' | $(KUBECTL) apply -f -
+	@echo '{"apiVersion":"pkg.crossplane.io/v1alpha1","kind":"ControllerConfig","metadata":{"name":"config-$*"},"spec":{"args":["-d"],"image":"$(BUILD_REGISTRY)/$*-$(ARCH)"}}' | $(KUBECTL) apply -f -
+	@echo '{"apiVersion":"pkg.crossplane.io/v1","kind":"Provider","metadata":{"name":"$*"},"spec":{"package":"$*-$(VERSION).gz","skipDependencyResolution": $(XPKG_SKIP_DEP_RESOLUTION), "packagePullPolicy":"Never","controllerConfigRef":{"name":"config-$*"}}}' | $(KUBECTL) apply -f -
 	@$(OK) deploying provider package $* $(VERSION)


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->
In the context of official provider testing, we would like to be able to run [uptest](https://github.com/upbound/uptest) using the family providers instead of the monolithic providers to avoid the CRD scaling issues we've been observing with them. Each resource provider in a provider family declares a package dependency to the family's config provider and the Crossplane RBAC manager is responsible for assigning the required RBAC rules on the config provider resources for the ClusterRole assigned to the family resource provider's K8s ServiceAccount. However, the RBAC manager [refuses](https://github.com/crossplane/crossplane/blob/ce52e336cef34e3879eabbc35b5cc5a04ede24e2/internal/controller/rbac/provider/roles/reconciler.go#L295) to do so if the reg/org of the resource provider's package does not match the config provider package's.

This PR proposes to make the dependency installation optional for the `local.xpkg.init` target so that while running uptests, we can manually install the config provider from the cache.


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
Tested against `upbound/provider-aws` in PR https://github.com/upbound/provider-aws/pull/903.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
