### PR TITLE
Bump UP_VERSION

### DIFF
--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -41,7 +41,7 @@ OLMBUNDLE_VERSION ?= v0.5.2
 OLMBUNDLE := $(TOOLS_HOST_DIR)/olm-bundle-$(OLMBUNDLE_VERSION)
 
 # the version of up to use
-UP_VERSION ?= v0.16.1
+UP_VERSION ?= v0.19.2
 UP_CHANNEL ?= stable
 UP := $(TOOLS_HOST_DIR)/up-$(UP_VERSION)
 


### PR DESCRIPTION
Consume new `up` CLI version required for build after package meta API version was bumped (e.g. upbound/provider-aws#882).

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->



I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

update Makefile locally:
```
-UP_VERSION = v0.17.0
+UP_VERSION = v0.19.2
```

build:
```
make SUBPACKAGES="config" VERSION=v0.38.0 build.all 
[...]
```

push to registry:
```
make SUBPACKAGES="config" VERSION=v0.38.0 BRANCH_NAME=main publish
15:57:28 [ .. ] Batch processing smaller provider packages for: config
Pushing xpkg to xpkg.staging-eikeagoo.upbound.services/upbound/provider-family-azure:v0.38.0.
xpkg pushed to xpkg.staging-eikeagoo.upbound.services/upbound/provider-family-azure:v0.38.0
15:57:44 [ OK ] Done processing smaller provider packages for: config
```

extract and check CRD:
```
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    auth.upbound.io/config: |
      version: "2023-06-23"
      discriminant: spec.credentials.source
      sources:
      - name: Upbound
        docs: |
          # Upbound OpenID Connect (OIDC)

          Using Upbound OIDC to authenticate to Azure eliminates the need to store credentials in this control plane.

          You will need to:

          1. Create an **Azure Application** that will be used to authenticate `provider-azure`.
          [.....]
```



