### PR TITLE
Promote: do not set as "current" if it is a pre release

### DIFF
--- a/makelib/output.mk
+++ b/makelib/output.mk
@@ -30,6 +30,9 @@ S3_CP := aws s3 cp --only-show-errors
 S3_SYNC := aws s3 sync --only-show-errors
 S3_SYNC_DEL := aws s3 sync --only-show-errors --delete
 
+# We will not set the artifact as "current" if this is a pre-release build.
+PRE_RELEASE ?= false
+
 # ====================================================================================
 # Targets
 
@@ -61,7 +64,9 @@ output.publish:
 output.promote:
 	@$(INFO) promoting s3://$(S3_BUCKET)/$(CHANNEL)/$(VERSION)
 	@$(S3_SYNC_DEL) s3://$(S3_BUCKET)/build/$(BRANCH_NAME)/$(VERSION) s3://$(S3_BUCKET)/$(CHANNEL)/$(VERSION) || $(FAIL)
+ifneq ($(PRE_RELEASE),true)
 	@$(S3_SYNC_DEL) s3://$(S3_BUCKET)/build/$(BRANCH_NAME)/$(VERSION) s3://$(S3_BUCKET)/$(CHANNEL)/current || $(FAIL)
+endif
 	@$(OK) promoting s3://$(S3_BUCKET)/$(CHANNEL)/$(VERSION)
 
 publish.artifacts: output.publish


### PR DESCRIPTION
### Description of your changes

In Crossplane, we would like to ship pre-releases to get some early eyes on the release. 
However, we don't want this release to be set as the "current" version, which is used by some [installation](https://github.com/crossplane/crossplane/blob/ee4cff4f70505083bf3f054e32ec938ecb373d01/install.sh#L6) scripts to identify the latest stable version.

See the relevant discussion [here](https://github.com/crossplane/crossplane/pull/4871#discussion_r1371900396).

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

I'll test this in CI since it requires cloud credentials and is a straightforward minimal change.
