### PR TITLE
Add Crossplane CLI as a tool

### DIFF
--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -45,6 +45,11 @@ UP_VERSION ?= v0.12.2
 UP_CHANNEL ?= stable
 UP := $(TOOLS_HOST_DIR)/up-$(UP_VERSION)
 
+# the version of crossplane cli to use
+CROSSPLANE_CLI_VERSION ?= v1.14.5
+CROSSPLANE_CLI_CHANNEL ?= stable
+CROSSPLANE_CLI := $(TOOLS_HOST_DIR)/crossplane-cli-$(CROSSPLANE_CLI_VERSION)
+
 # the version of helm 3 to use
 USE_HELM3 ?= false
 HELM3_VERSION ?= v3.9.1
@@ -127,6 +132,13 @@ $(UP):
 	@curl -fsSLo $(UP) --create-dirs https://cli.upbound.io/$(UP_CHANNEL)/$(UP_VERSION)/bin/$(SAFEHOST_PLATFORM)/up?source=build || $(FAIL)
 	@chmod +x $(UP)
 	@$(OK) installing up $(UP_VERSION)
+
+# Crossplane CLI download and install
+$(CROSSPLANE_CLI):
+	@$(INFO) installing Crossplane CLI $(CROSSPLANE_CLI_VERSION)
+	@curl -fsSLo $(CROSSPLANE_CLI) --create-dirs https://releases.crossplane.io/$(CROSSPLANE_CLI_CHANNEL)/$(CROSSPLANE_CLI_VERSION)/bin/$(SAFEHOST_PLATFORM)/crank?source=build || $(FAIL)
+	@chmod +x $(CROSSPLANE_CLI)
+	@$(OK) installing Crossplane CLI $(CROSSPLANE_CLI_VERSION)
 
 # helm download and install only if helm3 not enabled
 ifeq ($(USE_HELM3),false)


### PR DESCRIPTION
### Description of your changes

This will enable leveraging functionality like render in the build pipelines.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```make
xrender: $(CROSSPLANE_CLI)
	@$(INFO) rendering composition templates for $(COMPOSITION)
	@$(CROSSPLANE_CLI) beta render $(RENDER_DIR)/$(COMPOSITION)/xr.yaml $(CONFIGURATIONS_DIR)/$(COMPOSITION)/composition.yaml $(RENDER_DIR)/functions.yaml -o $(RENDER_DIR)/$(COMPOSITION)/observed.yaml
```

