### PR TITLE
Add yq As a Tool

### DIFF
--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -71,6 +71,11 @@ KUTTL := $(TOOLS_HOST_DIR)/kuttl-$(KUTTL_VERSION)
 # the version of uptest to use
 UPTEST_VERSION ?= v0.1.0
 UPTEST := $(TOOLS_HOST_DIR)/uptest-$(UPTEST_VERSION)
+
+# the version of yq to use
+YQ_VERSION ?= v4.40.5
+YQ := $(TOOLS_HOST_DIR)/yq-$(YQ_VERSION)
+
 # ====================================================================================
 # Common Targets
 
@@ -83,6 +88,7 @@ k8s_tools.buildvars:
 	@echo HELM=$(HELM)
 	@echo HELM3=$(HELM3)
 	@echo KUTTL=$(KUTTL)
+	@echo YQ=$(YQ)
 
 build.vars: k8s_tools.buildvars
 
@@ -179,3 +185,10 @@ $(UPTEST):
 	@chmod +x $(UPTEST)
 	@$(OK) installing uptest $(UPTEST)
 
+# yq download and install
+$(YQ):
+	@$(INFO) installing yq $(YQ_VERSION)
+	@mkdir -p $(TOOLS_HOST_DIR) && \
+	curl -fsSLo $(YQ) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(SAFEHOST_PLATFORM) && \
+	chmod +x $(YQ) || $(FAIL)
+	@$(OK) installing yq $(YQ_VERSION)


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

We are planning to use `kustomize` to process the family provider CRDs. `kustomize` outputs a multi-document YAML that contains all the processed CRDs and the `up xpkg batch` command relies on the controller-tools naming conventions for the CRD files to decide which CRD goes into which family provider package. Thus it cannot currently partition CRDs if they are in a single file. I checked the possibility of a content based filter (instead of relying on the generated file name) but the  interface is [`io.ReadCloser`](https://pkg.go.dev/io#ReadCloser), which processes a byte stream and is not aware of the YAML documents. Implementing a content filter will introduce unnecessary complexity due to the mismatching abstraction layers. Also considered a filtering [`parser.Parser`](https://pkg.go.dev/github.com/crossplane/crossplane-runtime/pkg/parser#Parser) implementation but that interface returns a concrete `parser.Package` (struct), which does not allow writes to its content list. So, that approach would require us to change the `parser.Parser` interface.

Instead of introducing `yq`, we first implemented a bash script processing the multi-doc YAML file line-by-line and splitting the over 900 CRDs of the official AWS provider family and it takes ~70 s on an M2 Mac to do so. Doing experiments with `yq`, it completes in ~10 s. So, we would like to use `yq` for splitting the multi-doc YAML output from `kustomize`.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
Tested both on the darwin ARM64 & linux AMD64 platforms.