### PR TITLE
Always use the kind kubectl context, even if the cluster exists

### DIFF
--- a/makelib/controlplane.mk
+++ b/makelib/controlplane.mk
@@ -20,6 +20,8 @@ CONTROLPLANE_DUMP_DIRECTORY ?= $(OUTPUT_DIR)/controlplane-dump
 controlplane.up: $(UP) $(KUBECTL) $(KIND)
 	@$(INFO) setting up controlplane
 	@$(KIND) get kubeconfig --name $(KIND_CLUSTER_NAME) >/dev/null 2>&1 || $(KIND) create cluster --name=$(KIND_CLUSTER_NAME)
+	@$(INFO) "setting kubectl context to kind-$(KIND_CLUSTER_NAME)"
+	@$(KUBECTL) config use-context "kind-$(KIND_CLUSTER_NAME)"
 ifndef CROSSPLANE_ARGS
 	@$(INFO) setting up crossplane core without args
 	@$(KUBECTL) -n $(CROSSPLANE_NAMESPACE) get cm universal-crossplane-config >/dev/null 2>&1 || $(UP) uxp install $(UXP_VERSION) --namespace=$(CROSSPLANE_NAMESPACE) $(UXP_INSTALL_OPTS)


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Frequently when developing providers, I reuse the kind cluster. Occasionally, I've switched kubectl contexts since the last time I ran `make e2e`, and then the build module tries to install crossplane on whatever other kubernetes context I've switched to. 

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

I've been using this locally for my tests in both provider-upjet-aws and provider-upjet-kafka.
