### PR TITLE
Allow env var to always publish

### DIFF
--- a/makelib/xpkg.mk
+++ b/makelib/xpkg.mk
@@ -116,9 +116,13 @@ else
 build.artifacts.platform: do.skip.xpkgs
 endif
 
-# only publish package for main / master and release branches
-# TODO(hasheddan): remove master and support overriding
-ifneq ($(filter main master release-%,$(BRANCH_NAME)),)
+# only publish package for main / master and release branches, unless the DO_PUBLISH override is set to true
+DO_PUBLISH ?= false
+ifneq ($(filter main release-%,$(BRANCH_NAME)),)
+DO_PUBLISH = true
+endif
+
+ifeq ($(DO_PUBLISH),true)
 publish.artifacts: $(foreach r,$(XPKG_REG_ORGS), $(foreach x,$(XPKGS),xpkg.release.publish.$(r).$(x)))
 endif
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Actually do the `# TODO(hasheddan): remove master and support overriding` from the makefile.

This removes `master` from the list of branch names that get published, and adds support for an env var, tentatively named `DO_PUBLISH`, which will cause the build module to publish regardless of branch.

If anyone has a better suggestion for the env var name I'm happy to change it.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
